### PR TITLE
fix install and run scripts

### DIFF
--- a/src/api/install.sh
+++ b/src/api/install.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 python3 -m venv .venv
 source .venv/bin/activate
 pip3 install -r requirements.txt

--- a/src/api/run.sh
+++ b/src/api/run.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 source .venv/bin/activate
 uvicorn app:app
 deactivate


### PR DESCRIPTION
Added the line `#!/bin/bash` to the beginning of install.sh and run.sh, since the line after venv creation wouldn't work without it