### PR TITLE
Add signup, login, and logout API endpoints

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,11 +1,15 @@
+from datetime import datetime, timedelta, timezone
 import os
-
+import secrets
 import aiosqlite
 import boto3
+from argon2 import PasswordHasher
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import JSONResponse, Response
+from starlette.responses import JSONResponse, Response, RedirectResponse
 from starlette.routing import Route
+
+hasher = PasswordHasher()
 
 s3 = boto3.resource(
     service_name="s3",
@@ -14,28 +18,103 @@ s3 = boto3.resource(
     endpoint_url=os.environ["S3_ENDPOINT"])
 
 DB_PATH = "/var/lib/mkc-api/data/mkc.db"
-
 DEBUG = False
+RESET_DATABASE = False
+
 if DEBUG:
     import debugpy
     debugpy.listen(("0.0.0.0", 5678))
     debugpy.wait_for_client()  # blocks execution until client is attached
 
 async def init_db():
+    if RESET_DATABASE:
+        open(DB_PATH, 'w').close()
+
     async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute("CREATE TABLE IF NOT EXISTS users (name TEXT PRIMARY KEY)")
+        await db.execute("pragma journal_mode = WAL;")
+        await db.execute("pragma synchronous = NORMAL;")
+        await db.execute("""CREATE TABLE IF NOT EXISTS players(
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL)""")
+        await db.execute("""CREATE TABLE IF NOT EXISTS users(
+            id INTEGER PRIMARY KEY,
+            player_id INTEGER REFERENCES players(id),
+            email TEXT UNIQUE,
+            password_hash TEXT)""")
+        await db.execute("""CREATE TABLE IF NOT EXISTS sessions(
+            session_id TEXT PRIMARY KEY NOT NULL,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            expires_on INTEGER NOT NULL) WITHOUT ROWID""")
         await db.commit()
 
-async def add_user(request: Request) -> Response:
+async def sign_up(request: Request) -> Response:
+    body = await request.json()
+    email = body["email"] # TODO: Email Verification
+    password_hash = hasher.hash(body["password"])
     async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute("INSERT INTO users VALUES (?)", [request.query_params["name"]])
+        async with db.execute("INSERT INTO users(email, password_hash) VALUES (?, ?)", (email, password_hash)) as cursor:
+            user_id = cursor.lastrowid
         await db.commit()
-    return Response(status_code=200)
+    
+    return JSONResponse({'id': user_id, 'email': email}, status_code=201)
+
+async def login(request: Request) -> Response:
+    body = await request.json()
+    email = body["email"]
+    password = body["password"]
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute("SELECT id, password_hash FROM users WHERE email = ?", (email, )) as cursor:
+            row = await cursor.fetchone()
+            if row is None:
+                return Response("Invalid login details", status_code=401)
+            user_id = row[0]
+            password_hash = row[1]
+
+    is_valid_password = hasher.verify(password_hash, password)
+    if not is_valid_password:
+        return Response("Invalid login details", status_code=401)
+    
+    session_id = secrets.token_hex(16)
+    max_age = timedelta(days=365)
+    expiration_date = datetime.now(timezone.utc) + max_age
+
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("INSERT INTO sessions(session_id, user_id, expires_on) VALUES (?, ?, ?)", (session_id, user_id, expiration_date.timestamp()))
+        await db.commit()
+
+    resp = RedirectResponse('/', status_code=303)
+    resp.set_cookie('session', session_id, max_age=max_age.total_seconds())
+    return resp
+
+async def logout(request: Request) -> Response:
+    session_id = request.cookies["session"]
+
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("DELETE FROM sessions WHERE session_id = ?", (session_id, ))
+        await db.commit()
+    resp = RedirectResponse('/', status_code=303)
+    resp.delete_cookie('session')
+    return resp
+
+async def current_user(request: Request) -> Response:
+    session_id = request.cookies["session"]
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute("SELECT u.id, u.email, u.password_hash FROM users u JOIN sessions s on s.user_id = u.id WHERE session_id = ?", (session_id, )) as cursor:
+            row = await cursor.fetchone()
+            if row is None:
+                return Response("Not logged in", status_code=401)
+            return JSONResponse({ 'id': row[0], 'email': row[1], 'password_hash': row[2] })
 
 async def list_users(request: Request) -> JSONResponse:
     async with aiosqlite.connect(DB_PATH) as db:
-        async with db.execute("SELECT name FROM users") as cursor:
-            names = [row[0] for row in await cursor.fetchall()]
+        async with db.execute("SELECT id, email, password_hash FROM users") as cursor:
+            names = [{ 'id': row[0], 'email': row[1], 'password_hash': row[2] } for row in await cursor.fetchall()]
+    return JSONResponse({'users': names})
+
+async def list_players(request: Request) -> JSONResponse:
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute("SELECT id, name FROM players") as cursor:
+            names = [{ 'id': row[0], 'name': row[1] } for row in await cursor.fetchall()]
     return JSONResponse({'users': names})
 
 async def homepage(request):
@@ -73,10 +152,14 @@ async def s3_write(request: Request):
 
 routes = [
     Route('/api', homepage),
-    Route('/api/user/list', list_users),
     Route('/api/s3', s3_read),
     Route('/api/s3', s3_write, methods=["POST"]),
-    Route('/api/user', add_user, methods=["POST"])
+    Route('/api/user/signup', sign_up, methods=["POST"]),
+    Route('/api/user/login', login, methods=["POST"]),
+    Route('/api/user/logout', logout, methods=["POST"]),
+    Route('/api/player/list', list_players),
+    Route('/api/user/list', list_users),
+    Route('/api/user/me', current_user),
 ]
 
 app = Starlette(debug=True, routes=routes, on_startup=[init_db])

--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -1,6 +1,8 @@
 aiosqlite==0.17.0
 anyio==3.6.1
+argon2-cffi==21.3.0
 asgiref==3.5.2
+boto3==1.24.29
 click==8.1.3
 debugpy==1.6.0
 h11==0.13.0
@@ -9,4 +11,3 @@ sniffio==1.2.0
 starlette==0.20.3
 typing_extensions==4.2.0
 uvicorn==0.17.6
-boto3==1.24.29


### PR DESCRIPTION
Schema:
```sql
CREATE TABLE IF NOT EXISTS players(
    id INTEGER PRIMARY KEY,
    name TEXT NOT NULL)

CREATE TABLE IF NOT EXISTS users(
    id INTEGER PRIMARY KEY,
    player_id INTEGER REFERENCES players(id),
    email TEXT UNIQUE,
    password_hash TEXT)

CREATE TABLE IF NOT EXISTS sessions(
    session_id TEXT PRIMARY KEY NOT NULL,
    user_id INTEGER NOT NULL REFERENCES users(id),
    expires_on INTEGER NOT NULL) WITHOUT ROWID
```

users represents logins, players represent entries on the player registry. We treat these as separate tables because:
1. Not all players will have a login (e.g. they may have TT data, but not have an account)
2. Not all users will have a player (e.g. it may be a root user used for admin tasks, they may not have completed their registration yet, or it might be used for API access only)

sessions table is used as a mapping to store session cookie value to user id, so that if they have the session cookie then it will remember them whenever they log in again. The table allows multiple session cookies per user which is needed because the user might have multiple devices and each will have its own cookie