### PR TITLE
temp fix for bind_request_body bug

### DIFF
--- a/src/backend/api/endpoints/tournaments.py
+++ b/src/backend/api/endpoints/tournaments.py
@@ -43,7 +43,7 @@ async def create_series(request: Request, body: SeriesRequestData) -> JSONRespon
 
 @bind_request_body(EditSeriesRequestData)
 @require_series_permission(series_permissions.EDIT_SERIES)
-async def edit_series(request: Request, body: SeriesRequestData) -> JSONResponse:
+async def edit_series(request: Request, body: EditSeriesRequestData) -> JSONResponse:
     series_id = request.path_params['series_id']
     command = EditSeriesCommand(body, series_id)
     await handle(command)

--- a/src/backend/common/data/commands/tournament_series.py
+++ b/src/backend/common/data/commands/tournament_series.py
@@ -4,7 +4,7 @@ from typing import Any
 import msgspec
 
 from common.data.commands import Command, save_to_command_log
-from common.data.models import Problem, Series, SeriesFilter, SeriesRequestData
+from common.data.models import Problem, Series, SeriesFilter, EditSeriesRequestData, SeriesRequestData
 import common.data.s3 as s3
 
 
@@ -31,7 +31,7 @@ class CreateSeriesCommand(Command[None]):
 @save_to_command_log
 @dataclass
 class EditSeriesCommand(Command[None]):
-    body: SeriesRequestData
+    body: EditSeriesRequestData
     series_id: int
 
     async def handle(self, db_wrapper, s3_wrapper):

--- a/src/backend/common/data/models/discord_integration.py
+++ b/src/backend/common/data/models/discord_integration.py
@@ -33,6 +33,14 @@ class Discord:
     global_name: str | None
     avatar: str | None
 
+# @dataclass
+# class MyDiscordData(Discord):
+#     user_id: int
 @dataclass
-class MyDiscordData(Discord):
+class MyDiscordData:
+    discord_id: str
+    username: str
+    discriminator: str
+    global_name: str | None
+    avatar: str | None
     user_id: int

--- a/src/backend/common/data/models/friend_codes.py
+++ b/src/backend/common/data/models/friend_codes.py
@@ -31,6 +31,10 @@ class EditFriendCodeRequestData:
 class EditPrimaryFriendCodeRequestData:
     id: int
 
+# @dataclass
+# class ModEditPrimaryFriendCodeRequestData(EditPrimaryFriendCodeRequestData):
+#     player_id: int
 @dataclass
-class ModEditPrimaryFriendCodeRequestData(EditPrimaryFriendCodeRequestData):
+class ModEditPrimaryFriendCodeRequestData:
+    id: int
     player_id: int

--- a/src/backend/common/data/models/player_bans.py
+++ b/src/backend/common/data/models/player_bans.py
@@ -10,8 +10,18 @@ class PlayerBan:
     reason: str
     comment: str
 
+# @dataclass
+# class PlayerBanHistorical(PlayerBan):
+#     unbanned_by: int | None = None
 @dataclass
-class PlayerBanHistorical(PlayerBan):
+class PlayerBanHistorical:
+    player_id: int
+    banned_by: int
+    is_indefinite: bool
+    ban_date: int
+    expiration_date: int
+    reason: str
+    comment: str
     unbanned_by: int | None = None
 
 @dataclass
@@ -58,8 +68,24 @@ class PlayerBanFilter:
     comment: str | None = None
     page: int | None = None
 
+# @dataclass
+# class PlayerBanHistoricalFilter(PlayerBanFilter):
+#     unbanned_by: str | None = None
+#     unbanned_before: int | None = None
+#     unbanned_after: int | None = None
 @dataclass
-class PlayerBanHistoricalFilter(PlayerBanFilter):
+class PlayerBanHistoricalFilter:
+    player_id: int | None = None
+    name: str | None = None
+    banned_by: str | None = None
+    is_indefinite: bool | None = None
+    expires_before: int | None = None
+    expires_after: int | None = None
+    banned_before: int | None = None
+    banned_after: int | None = None
+    reason: str | None = None
+    comment: str | None = None
+    page: int | None = None
     unbanned_by: str | None = None
     unbanned_before: int | None = None
     unbanned_after: int | None = None

--- a/src/backend/common/data/models/roles.py
+++ b/src/backend/common/data/models/roles.py
@@ -55,7 +55,12 @@ class RemoveRoleRequestData:
     player_id: int
     role_name: str
 
-@dataclass
-class GrantRoleRequestData(RemoveRoleRequestData):
-    expires_on: int | None = None
+# @dataclass
+# class GrantRoleRequestData(RemoveRoleRequestData):
+#     expires_on: int | None = None
 
+@dataclass
+class GrantRoleRequestData:
+    player_id: int
+    role_name: str
+    expires_on: int | None = None

--- a/src/backend/common/data/models/squads.py
+++ b/src/backend/common/data/models/squads.py
@@ -20,8 +20,21 @@ class CreateSquadRequestData:
     selected_fc_id: int | None
     is_bagger_clause: bool
 
+# @dataclass
+# class ForceCreateSquadRequestData(CreateSquadRequestData):
+#     player_id: int
+#     is_checked_in: bool = False
+#     is_approved: bool = False
+
 @dataclass
-class ForceCreateSquadRequestData(CreateSquadRequestData):
+class ForceCreateSquadRequestData:
+    squad_color: int
+    squad_name: str | None
+    squad_tag: str | None
+    mii_name: str | None
+    can_host: bool
+    selected_fc_id: int | None
+    is_bagger_clause: bool
     player_id: int
     is_checked_in: bool = False
     is_approved: bool = False
@@ -33,8 +46,17 @@ class EditMySquadRequestData:
     squad_tag: str | None
     squad_color: int | None
 
+# @dataclass
+# class EditSquadRequestData(EditMySquadRequestData):
+#     is_registered: bool | None = None
+#     is_approved: bool | None = None
+
 @dataclass
-class EditSquadRequestData(EditMySquadRequestData):
+class EditSquadRequestData:
+    squad_id: int
+    squad_name: str | None
+    squad_tag: str | None
+    squad_color: int | None
     is_registered: bool | None = None
     is_approved: bool | None = None
 

--- a/src/backend/common/data/models/teams.py
+++ b/src/backend/common/data/models/teams.py
@@ -17,8 +17,23 @@ class RequestCreateTeamRequestData():
     mode: GameMode
     is_recruiting: bool
 
+# @dataclass
+# class CreateTeamRequestData(RequestCreateTeamRequestData):
+#     approval_status: Approval
+#     is_historical: bool
+#     is_active: bool
+
 @dataclass
-class CreateTeamRequestData(RequestCreateTeamRequestData):
+class CreateTeamRequestData:
+    name: str
+    tag: str
+    description: str
+    language: str
+    color: int
+    logo: str | None
+    game: Game
+    mode: GameMode
+    is_recruiting: bool
     approval_status: Approval
     is_historical: bool
     is_active: bool
@@ -183,8 +198,15 @@ class DeleteInviteRequestData():
     player_id: int
     roster_id: int
 
+# @dataclass
+# class InviteRosterPlayerRequestData(DeleteInviteRequestData):
+#     is_bagger_clause: bool
+
 @dataclass
-class InviteRosterPlayerRequestData(DeleteInviteRequestData):
+class InviteRosterPlayerRequestData():
+    team_id: int
+    player_id: int
+    roster_id: int
     is_bagger_clause: bool
 
 @dataclass

--- a/src/backend/common/data/models/tournament_registrations.py
+++ b/src/backend/common/data/models/tournament_registrations.py
@@ -26,8 +26,21 @@ class EditMyRegistrationRequestData():
     selected_fc_id: int | None
     squad_id: int | None
 
+# @dataclass
+# class EditPlayerRegistrationRequestData(EditMyRegistrationRequestData):
+#     player_id: int
+#     is_squad_captain: bool | None
+#     is_invite: bool
+#     is_checked_in: bool | None
+#     is_representative: bool | None
+#     is_bagger_clause: bool | None
+#     is_approved: bool | None
 @dataclass
-class EditPlayerRegistrationRequestData(EditMyRegistrationRequestData):
+class EditPlayerRegistrationRequestData:
+    mii_name: str | None
+    can_host: bool
+    selected_fc_id: int | None
+    squad_id: int | None
     player_id: int
     is_squad_captain: bool | None
     is_invite: bool

--- a/src/backend/common/data/models/tournament_series.py
+++ b/src/backend/common/data/models/tournament_series.py
@@ -17,10 +17,26 @@ class SeriesRequestData():
     organizer: str
     location: str | None
 
-@dataclass
-class EditSeriesRequestData(SeriesRequestData):
-    series_id: int
+# @dataclass
+# class EditSeriesRequestData(SeriesRequestData):
+#     series_id: int
     
+@dataclass
+class EditSeriesRequestData():
+    series_name: str
+    url: str | None
+    display_order: int
+    game: Game
+    mode: GameMode
+    is_historical: bool
+    is_public: bool
+    description: str
+    logo: str | None
+    ruleset: str
+    organizer: str
+    location: str | None
+    series_id: int
+
 @dataclass
 class Series():
     id: int

--- a/src/backend/common/data/models/tournament_templates.py
+++ b/src/backend/common/data/models/tournament_templates.py
@@ -1,11 +1,57 @@
 from dataclasses import dataclass
 
 from common.data.models.tournaments import CreateTournamentRequestData
+from common.data.models.common import Game, GameMode
 
+
+# @dataclass
+# class TournamentTemplateRequestData(CreateTournamentRequestData):
+#     template_name: str
 
 @dataclass
-class TournamentTemplateRequestData(CreateTournamentRequestData):
+class TournamentTemplateRequestData():
     template_name: str
+    name: str
+    game: Game
+    mode: GameMode
+    series_id: int | None
+    is_squad: bool
+    registrations_open: bool
+    date_start: int
+    date_end: int
+    description: str
+    use_series_description: bool
+    series_stats_include: bool
+    logo: str | None
+    use_series_logo: bool
+    url: str | None
+    registration_deadline: int | None
+    registration_cap: int | None
+    teams_allowed: bool
+    teams_only: bool
+    team_members_only: bool
+    min_squad_size: int | None
+    max_squad_size: int | None
+    squad_tag_required: bool
+    squad_name_required: bool
+    mii_name_required: bool
+    host_status_required: bool
+    checkins_enabled: bool
+    checkins_open: bool
+    min_players_checkin: int | None
+    verification_required: bool
+    verified_fc_required: bool
+    is_viewable: bool
+    is_public: bool
+    is_deleted: bool
+    show_on_profiles: bool
+    require_single_fc: bool
+    min_representatives: int | None
+    bagger_clause_enabled: bool
+    use_series_ruleset: bool
+    organizer: str | None
+    location: str | None
+    ruleset: str
 
 @dataclass
 class TournamentTemplate(TournamentTemplateRequestData):

--- a/src/frontend/src/lib/components/common/LoginRegister.svelte
+++ b/src/frontend/src/lib/components/common/LoginRegister.svelte
@@ -37,13 +37,13 @@
             <span class="item-label">
                 <label for="email">{$LL.EMAIL()}</label>
             </span>
-            <input name="email" type="email" />
+            <input name="email" type="email" required/>
         </div>
         <div class="field">
             <span class="item-label">
                 <label for="password">{$LL.PASSWORD()}</label>
             </span>
-            <input name="password" type="password" />
+            <input name="password" type="password" required/>
         </div>
         <Button extra_classes="login-btn" type="submit">{$LL.NAVBAR.LOGIN()}</Button>
         <Button extra_classes="register-btn" type="submit">{$LL.NAVBAR.REGISTER()}</Button>


### PR DESCRIPTION
There is some strange bug with dataclass inheritance, making a PR for this to document it for later since I have no clue what the root cause is. When `bind_request_body` is used on a dataclass which inherits from another class, the site will randomly think the object is of the parent class, and give an `AttributeError` saying `'ParentClass' object has no attribute 'SubclassAttr'`. Here is an example from today:

![image](https://i.imgur.com/lSaM25W.png)
![image](https://i.imgur.com/4u4pMns.png)
![image](https://i.imgur.com/cnDumQW.png)

As you can see, the `edit_registration` endpoint's body parameter is of type `EditPlayerRegistrationRequestData`. However, the error thinks that the body is of type `EditMyRegistrationRequestData` (which is the parent class of `EditPlayerRegistrationRequestData`) which does not have a `player_id` parameter, and the endpoint throws a 500 error.

The strange thing about this bug is that it does not always happen, it will just randomly start appearing after some time of the site being up. In the dev container, you can temporarily fix it by just doing Ctrl + S in a file which uses the dataclass for some reason, however this bug occurs in the prod site as well which is a problem for obvious reasons. For a temporary fix, I'm going to remove inheritance from all dataclass models that are used in `bind_request_body` for now so we can get something working for beta testing.