### PR TITLE
Better FC management, let mods edit player profiles, add player name change requests

### DIFF
--- a/src/backend/api/endpoints/player_registry.py
+++ b/src/backend/api/endpoints/player_registry.py
@@ -47,10 +47,25 @@ async def create_fc(request: Request, body: CreateFriendCodeRequestData) -> JSON
     await handle(command)
     return JSONResponse({})
 
-@bind_request_body(EditFriendCodeRequestData)
+@bind_request_body(ForceCreateFriendCodeRequestData)
+@require_permission(permissions.EDIT_PLAYER)
+async def force_create_fc(request: Request, body: ForceCreateFriendCodeRequestData) -> JSONResponse:
+    command = CreateFriendCodeCommand(body.player_id, body.fc, body.game, False, body.is_primary, True, body.description, True)
+    await handle(command)
+    return JSONResponse({})
+
+@bind_request_body(ForceEditFriendCodeRequestData)
+@require_permission(permissions.EDIT_PLAYER)
+async def force_edit_fc(request: Request, body: ForceEditFriendCodeRequestData) -> JSONResponse:
+    command = EditFriendCodeCommand(body.player_id, body.id, body.fc, body.is_primary, body.is_active, body.description)
+    await handle(command)
+    return JSONResponse({})
+
+@bind_request_body(EditMyFriendCodeRequestData)
 @require_logged_in
-async def edit_fc(request: Request, body: EditFriendCodeRequestData) -> JSONResponse:
-    command = EditFriendCodeCommand(body.id, body.fc, body.game, body.is_active, body.description)
+async def edit_my_fc(request: Request, body: EditMyFriendCodeRequestData) -> JSONResponse:
+    player_id = request.state.user.player_id
+    command = EditFriendCodeCommand(player_id, body.id, None, body.is_primary, None, body.description)
     await handle(command)
     return JSONResponse({})
 
@@ -74,7 +89,9 @@ routes = [
     Route('/api/registry/players/{id:int}', view_player),
     Route('/api/registry/players', list_players),
     Route('/api/registry/addFriendCode', create_fc, methods=['POST']),
-    Route('/api/registry/forceEditFriendCode', edit_fc, methods=['POST']),
+    Route('/api/registry/forceAddFriendCode', force_create_fc, methods=['POST']),
+    Route('/api/registry/forceEditFriendCode', force_edit_fc, methods=['POST']),
+    Route('/api/registry/editFriendCode', edit_my_fc, methods=['POST']),
     Route('/api/registry/setPrimaryFriendCode', set_primary_fc, methods=['POST']),
     Route('/api/registry/forcePrimaryFriendCode', force_primary_fc, methods=['POST'])
 ]

--- a/src/backend/api/endpoints/user_settings.py
+++ b/src/backend/api/endpoints/user_settings.py
@@ -33,9 +33,17 @@ async def edit_settings(request: Request, body: EditUserSettingsRequestData) -> 
         resp.set_cookie('color_scheme', body.color_scheme)
 
     return resp
+
+@bind_request_body(EditPlayerUserSettingsRequestData)
+@require_permission(permissions.EDIT_PLAYER)
+async def edit_player_user_settings(request: Request, body: EditPlayerUserSettingsRequestData) -> JSONResponse:
+    command = EditPlayerUserSettingsCommand(body)
+    await handle(command)
+    return JSONResponse({})
     
 
 routes = [
     Route('/api/user/settings', get_settings),
     Route('/api/user/settings/edit', edit_settings, methods=["POST"]),
+    Route('/api/user/settings/forceEdit', edit_player_user_settings, methods=["POST"]),
 ]

--- a/src/backend/common/data/commands/auth.py
+++ b/src/backend/common/data/commands/auth.py
@@ -223,6 +223,11 @@ class GetModNotificationsCommand(Command[ModNotifications]):
                     row = await cursor.fetchone()
                     assert row is not None
                     mod_notifications.pending_transfers = row[0]
+            if permissions.EDIT_PLAYER in string_perms:
+                async with db.execute("SELECT COUNT(id) FROM player_name_edit_requests WHERE approval_status='pending'") as cursor:
+                    row = await cursor.fetchone()
+                    assert row is not None
+                    mod_notifications.pending_player_name_changes = row[0]
         return mod_notifications
     
 @dataclass

--- a/src/backend/common/data/commands/friend_codes.py
+++ b/src/backend/common/data/commands/friend_codes.py
@@ -41,7 +41,7 @@ class CreateFriendCodeCommand(Command[None]):
                     if fc_count >= fc_limits[self.game]:
                         raise Problem("Player is at maximum friend codes for this game", status=400)
                 
-            async with db.execute("SELECT id FROM friend_codes WHERE fc = ? AND game = ? AND is_active = ?", (self.fc, self.game, True)) as cursor:
+            async with db.execute("SELECT id FROM friend_codes WHERE fc = ? AND game = ? AND (is_active = ? OR player_id = ?)", (self.fc, self.game, True, self.player_id)) as cursor:
                 row = await cursor.fetchone()
                 if row:
                     raise Problem("Another player is currently using this friend code for this game", status=400)
@@ -52,23 +52,37 @@ class CreateFriendCodeCommand(Command[None]):
 @save_to_command_log    
 @dataclass
 class EditFriendCodeCommand(Command[None]):
+    player_id: int
     id: int
-    fc: str
-    game: Game
-    is_active: bool
+    fc: str | None
+    is_primary: bool
+    is_active: bool | None
     description: str | None
 
     async def handle(self, db_wrapper, s3_wrapper):
-        # make sure FC is in 0000-0000-0000 format
-        match = re.fullmatch(r"\d{4}-\d{4}-\d{4}", self.fc)
-        if self.game != "mk8" and not match:
-            raise Problem("FC is in incorrect format", status=400)
         async with db_wrapper.connect() as db:
-            async with db.execute("SELECT id FROM friend_codes WHERE id != ? AND fc = ? AND game = ? AND is_active = ?", (self.id, self.fc, self.game, True)) as cursor:
+            async with db.execute("SELECT game, fc, is_active, is_primary FROM friend_codes WHERE id = ? AND player_id = ?", (self.id, self.player_id)) as cursor:
                 row = await cursor.fetchone()
-                if row:
-                    raise Problem("Another player is currently using this friend code for this game", status=400)
-            await db.execute("UPDATE friend_codes SET fc = ?, is_active = ?, description = ? WHERE id = ?", (self.fc, self.is_active, self.description, self.id))
+                if not row:
+                    raise Problem("FC not found", status=404)
+                game, curr_fc, curr_is_active, curr_is_primary = row
+            if self.fc is not None:
+                # make sure FC is in 0000-0000-0000 format
+                match = re.fullmatch(r"\d{4}-\d{4}-\d{4}", self.fc)
+                if game != "mk8" and not match:
+                    raise Problem("FC is in incorrect format", status=400)
+                async with db.execute("SELECT id FROM friend_codes WHERE id != ? AND fc = ? AND game = ? AND (is_active = ? OR player_id = ?)", (self.id, self.fc, game, True, self.player_id)) as cursor:
+                    row = await cursor.fetchone()
+                    if row:
+                        raise Problem("Another player is currently using this friend code for this game", status=400)
+            fc = curr_fc if self.fc is None else self.fc
+            is_active = curr_is_active if self.is_active is None else self.is_active
+            if not is_active and self.is_primary:
+                raise Problem("Inactive FCs cannot be primary", status=400)
+            # if this FC is now primary, make all the other FCs this player has for that game non-primary
+            if self.is_primary and not curr_is_primary:
+                await db.execute("UPDATE friend_codes SET is_primary = 0 WHERE player_id = ? AND game = ? AND id != ?", (self.player_id, game, self.id))
+            await db.execute("UPDATE friend_codes SET fc = ?, is_active = ?, description = ?, is_primary = ? WHERE id = ?", (fc, is_active, self.description, self.is_primary, self.id))
             await db.commit()
 
 @save_to_command_log

--- a/src/backend/common/data/commands/players.py
+++ b/src/backend/common/data/commands/players.py
@@ -101,9 +101,10 @@ class GetPlayerDetailedCommand(Command[PlayerDetailed | None]):
             
             name, country_code, is_hidden, is_shadow, is_banned = player_row
 
-            fc_query = "SELECT id, game, fc, is_verified, is_primary, description FROM friend_codes WHERE player_id = ?"
+            fc_query = "SELECT id, game, fc, is_verified, is_primary, description, is_active FROM friend_codes WHERE player_id = ?"
             friend_code_rows = await db.execute_fetchall(fc_query, (self.id, ))
-            friend_codes = [FriendCode(id, fc, game, self.id, bool(is_verified), bool(is_primary), description) for id, game, fc, is_verified, is_primary, description in friend_code_rows]
+            friend_codes = [FriendCode(id, fc, game, self.id, bool(is_verified), bool(is_primary), description, bool(is_active)) for id, game, fc, is_verified, is_primary, 
+                            description, is_active in friend_code_rows]
 
             user_query = "SELECT id FROM users WHERE player_id = ?"
             async with db.execute(user_query, (self.id,)) as cursor:
@@ -239,7 +240,7 @@ class ListPlayersCommand(Command[PlayerList]):
                         fc_where_clauses.append("f.fc LIKE ?")
                         fc_variable_parameters.append(f"%{filter.name_or_fc}%")
                 fc_where_clause = "" if not len(fc_where_clauses) else f"AND {' AND '.join(fc_where_clauses)}"
-            friend_codes_query = f"""SELECT f.id, f.fc, f.game, f.player_id, f.is_verified, f.is_primary, f.description FROM friend_codes f WHERE f.player_id IN (
+            friend_codes_query = f"""SELECT f.id, f.fc, f.game, f.player_id, f.is_verified, f.is_primary, f.description, f.is_active FROM friend_codes f WHERE f.player_id IN (
                 SELECT p.id FROM players p
                 LEFT JOIN users u ON u.player_id = p.id
                 LEFT JOIN user_discords d ON u.id = d.user_id
@@ -280,7 +281,7 @@ class ListPlayersCommand(Command[PlayerList]):
                 async with db.execute(friend_codes_query, (*(variable_parameters + fc_variable_parameters), limit, offset)) as cursor:
                     rows = await cursor.fetchall()
                     for row in rows:
-                        id, fc, game, player_id, is_verified, is_primary, description = row
-                        friend_codes[player_id].append(FriendCode(id, fc, game, player_id, is_verified, is_primary, description))
+                        id, fc, game, player_id, is_verified, is_primary, description, is_active = row
+                        friend_codes[player_id].append(FriendCode(id, fc, game, player_id, bool(is_verified), bool(is_primary), description, bool(is_active)))
                 
             return PlayerList(players, player_count, page_count)

--- a/src/backend/common/data/commands/players.py
+++ b/src/backend/common/data/commands/players.py
@@ -4,6 +4,7 @@ import re
 
 from common.data.commands import Command, save_to_command_log
 from common.data.models import *
+from datetime import datetime, timedelta, timezone
 
 
 @save_to_command_log
@@ -148,7 +149,14 @@ class GetPlayerDetailedCommand(Command[PlayerDetailed | None]):
                     if discord_row is not None:
                         discord = Discord(*discord_row)
 
-            return PlayerDetailed(self.id, name, country_code, is_hidden, is_shadow, is_banned, discord, friend_codes, rosters, ban_info, user_settings)
+            name_changes: list[PlayerNameChange] = []
+            async with db.execute("SELECT id, name, date, approval_status FROM player_name_edit_requests WHERE player_id = ? AND approval_status != 'denied'", (self.id,)) as cursor:
+                rows = await cursor.fetchall()
+                for row in rows:
+                    request_id, request_name, request_date, request_approval = row
+                    name_changes.append(PlayerNameChange(request_id, request_name, request_date, request_approval))
+
+            return PlayerDetailed(self.id, name, country_code, bool(is_hidden), bool(is_shadow), bool(is_banned), discord, friend_codes, rosters, ban_info, user_settings, name_changes)
         
 @dataclass
 class ListPlayersCommand(Command[PlayerList]):
@@ -264,7 +272,7 @@ class ListPlayersCommand(Command[PlayerList]):
                     player_discord = None
                     if discord_id:
                         player_discord = Discord(discord_id, d_username, d_discriminator, d_global_name, d_avatar)
-                    player = PlayerDetailed(id, name, country_code, is_hidden, is_shadow, is_banned, player_discord, [], [], None, None)
+                    player = PlayerDetailed(id, name, country_code, is_hidden, is_shadow, is_banned, player_discord, [], [], None, None, [])
                     players.append(player)
                     friend_codes[player.id] = player.friend_codes
 
@@ -285,3 +293,74 @@ class ListPlayersCommand(Command[PlayerList]):
                         friend_codes[player_id].append(FriendCode(id, fc, game, player_id, bool(is_verified), bool(is_primary), description, bool(is_active)))
                 
             return PlayerList(players, player_count, page_count)
+
+@save_to_command_log
+@dataclass
+class RequestEditPlayerNameCommand(Command[None]):
+    player_id: int
+    name: str
+
+    async def handle(self, db_wrapper, s3_wrapper):
+        async with db_wrapper.connect() as db:
+            async with db.execute("SELECT name FROM players WHERE id = ?", (self.player_id,)) as cursor:
+                row = await cursor.fetchone()
+                if not row:
+                    raise Problem("Player not found", status=404)
+                curr_name = row[0]
+                if curr_name == self.name:
+                    raise Problem("Name must be different than current name", status=400)
+            async with db.execute("SELECT date FROM player_name_edit_requests WHERE player_id = ? AND date > ? AND approval_status != 'denied' LIMIT 1",
+                                    (self.player_id, (datetime.now(timezone.utc)-timedelta(days=90)).timestamp())) as cursor:
+                row = await cursor.fetchone()
+                if row:
+                    raise Problem("Player has requested name change in the last 90 days", status=400)
+            creation_date = int(datetime.now(timezone.utc).timestamp())
+            await db.execute("INSERT INTO player_name_edit_requests(player_id, name, date, approval_status) VALUES (?, ?, ?, ?)", 
+                             (self.player_id, self.name, creation_date, "pending"))
+            await db.commit()
+                    
+@dataclass
+class ListPlayerNameRequestsCommand(Command[list[PlayerNameRequest]]):
+    approval_status: Approval
+
+    async def handle(self, db_wrapper, s3_wrapper):
+        async with db_wrapper.connect() as db:
+            name_requests: list[PlayerNameRequest] = []
+            async with db.execute("""SELECT p.id, p.name, p.country_code, r.id, r.name, r.date, r.approval_status
+                                    FROM player_name_edit_requests r
+                                    JOIN players p ON r.player_id = p.id
+                                    WHERE r.approval_status = ?""", (self.approval_status,)) as cursor:
+                rows = await cursor.fetchall()
+                for row in rows:
+                    player_id, player_name, player_country, request_id, request_name, date, approval_status = row
+                    name_requests.append(PlayerNameRequest(request_id, player_id, player_name, player_country, request_name, date, approval_status))
+        return name_requests
+    
+@save_to_command_log
+@dataclass
+class ApprovePlayerNameRequestCommand(Command[None]):
+    request_id: int
+
+    async def handle(self, db_wrapper, s3_wrapper):
+        async with db_wrapper.connect() as db:
+            async with db.execute("SELECT player_id, name FROM player_name_edit_requests WHERE id = ?", (self.request_id,)) as cursor:
+                row = await cursor.fetchone()
+                if not row:
+                    raise Problem("Name edit request not found", status=400)
+                player_id, name = row
+            await db.execute("UPDATE players SET name = ? WHERE id = ?", (name, player_id))
+            await db.execute("UPDATE player_name_edit_requests SET approval_status = 'approved' WHERE id = ?", (self.request_id,))
+            await db.commit()
+
+@save_to_command_log
+@dataclass
+class DenyPlayerNameRequestCommand(Command[None]):
+    request_id: int
+
+    async def handle(self, db_wrapper, s3_wrapper):
+        async with db_wrapper.connect() as db:
+            async with db.execute("UPDATE player_name_edit_requests SET approval_status = 'denied' WHERE id = ?", (self.request_id,)) as cursor:
+                rowcount = cursor.rowcount
+                if rowcount == 0:
+                    raise Problem("Name edit request not found", status=404)
+                await db.commit()

--- a/src/backend/common/data/commands/teams.py
+++ b/src/backend/common/data/commands/teams.py
@@ -826,7 +826,7 @@ class RequestEditRosterCommand(Command[None]):
         async with db_wrapper.connect() as db:
             # check if this roster has made a request in the last 90 days
             async with db.execute("SELECT date FROM roster_edit_requests WHERE roster_id = ? AND date > ? AND approval_status != 'denied' LIMIT 1",
-                                  (self.roster_id, (datetime.now(timezone.utc)-timedelta(minutes=90)).timestamp())) as cursor:
+                                  (self.roster_id, (datetime.now(timezone.utc)-timedelta(days=90)).timestamp())) as cursor:
                 row = await cursor.fetchone()
                 if row:
                     raise Problem("Roster has requested name/tag change in the last 90 days", status=400)

--- a/src/backend/common/data/db/tables.py
+++ b/src/backend/common/data/db/tables.py
@@ -42,7 +42,7 @@ class FriendCode(TableModel):
     def get_create_table_command():
         return """CREATE TABLE IF NOT EXISTS friend_codes(
             id INTEGER PRIMARY KEY,
-            player_id INTEGER NOT NULL,
+            player_id INTEGER NOT NULL REFERENCES players(id),
             game TEXT NOT NULL,
             fc TEXT NOT NULL,
             is_verified BOOLEAN NOT NULL,

--- a/src/backend/common/data/db/tables.py
+++ b/src/backend/common/data/db/tables.py
@@ -829,6 +829,24 @@ class PlayerBansHistorical(TableModel):
             reason TEXT NOT NULL,
             comment TEXT NOT NULL)"""
     
+@dataclass
+class PlayerNameEditRequest(TableModel):
+    id: int
+    player_id: int
+    name: str
+    date: int
+    approval_status: str
+
+    @staticmethod
+    def get_create_table_command() -> str:
+        return """CREATE TABLE IF NOT EXISTS player_name_edit_requests (
+            id INTEGER PRIMARY KEY,
+            player_id INTEGER NOT NULL REFERENCES players(id),
+            name TEXT NOT NULL,
+            date INTEGER NOT NULL,
+            approval_status TEXT NOT NULL
+            )"""
+    
 all_tables : list[type[TableModel]] = [
     Player, FriendCode, User, Session, UserDiscord, Role, Permission, UserRole, RolePermission, 
     TournamentSeries, Tournament, TournamentTemplate, TournamentSquad, TournamentPlayer,
@@ -837,4 +855,5 @@ all_tables : list[type[TableModel]] = [
     SeriesRole, SeriesPermission, SeriesRolePermission, UserSeriesRole, 
     TournamentRole, TournamentPermission, TournamentRolePermission, UserTournamentRole,
     RosterInvite, TeamEditRequest, RosterEditRequest,
-    UserSettings, NotificationContent, Notifications, CommandLog, PlayerBans, PlayerBansHistorical]
+    UserSettings, NotificationContent, Notifications, CommandLog, PlayerBans, PlayerBansHistorical,
+    PlayerNameEditRequest]

--- a/src/backend/common/data/models/friend_codes.py
+++ b/src/backend/common/data/models/friend_codes.py
@@ -11,6 +11,7 @@ class FriendCode:
     is_verified: int
     is_primary: int
     description: str | None = None
+    is_active: bool = True
 
 @dataclass
 class CreateFriendCodeRequestData:
@@ -20,10 +21,25 @@ class CreateFriendCodeRequestData:
     description: str | None
 
 @dataclass
-class EditFriendCodeRequestData:
-    id: int
+class ForceCreateFriendCodeRequestData:
+    player_id: int
     fc: str
     game: Game
+    is_primary: bool
+    description: str | None
+
+@dataclass
+class EditMyFriendCodeRequestData:
+    id: int
+    is_primary: bool
+    description: str | None
+
+@dataclass
+class ForceEditFriendCodeRequestData:
+    player_id: int
+    id: int
+    fc: str
+    is_primary: bool
     is_active: bool
     description: str | None
 

--- a/src/backend/common/data/models/players.py
+++ b/src/backend/common/data/models/players.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from common.data.models.common import Game, CountryCode
+from common.data.models.common import Game, CountryCode, Approval
 from common.data.models.friend_codes import FriendCode, CreateFriendCodeRequestData
 from common.data.models.user_settings import UserSettings
 from common.data.models.player_bans import PlayerBanBasic
@@ -36,10 +36,18 @@ class PlayerRoster:
     is_bagger_clause: bool
 
 @dataclass
+class PlayerNameChange:
+    id: int
+    name: str
+    date: int
+    approval_status: Approval
+
+@dataclass
 class PlayerDetailed(PlayerAndFriendCodes):
     rosters: list[PlayerRoster]
     ban_info: PlayerBanBasic | None
     user_settings: UserSettings | None
+    name_changes: list[PlayerNameChange]
 
 @dataclass
 class PlayerList:
@@ -79,3 +87,21 @@ class PlayerFilter:
     page: int | None = None
     squad_id: int | None = None
     matching_fcs_only: bool = False
+
+@dataclass
+class PlayerRequestNameRequestData:
+    name: str
+
+@dataclass
+class PlayerNameRequest:
+    id: int
+    player_id: int
+    player_name: str
+    player_country: CountryCode
+    request_name: str
+    date: int
+    approval_status: Approval
+
+@dataclass
+class ApprovePlayerNameRequestData:
+    request_id: int

--- a/src/backend/common/data/models/user_settings.py
+++ b/src/backend/common/data/models/user_settings.py
@@ -18,3 +18,12 @@ class EditUserSettingsRequestData:
     language: Literal['de', 'en-gb', 'en-us', 'es', 'fr', 'ja'] | None = None
     color_scheme: Literal['light', 'dark'] | None = None
     timezone: str | None = None
+
+@dataclass
+class EditPlayerUserSettingsRequestData:
+    player_id: int
+    avatar: str | None = None
+    about_me: str | None = None
+    language: Literal['de', 'en-gb', 'en-us', 'es', 'fr', 'ja'] | None = None
+    color_scheme: Literal['light', 'dark'] | None = None
+    timezone: str | None = None

--- a/src/backend/common/data/models/users.py
+++ b/src/backend/common/data/models/users.py
@@ -15,6 +15,7 @@ class ModNotifications:
     pending_teams: int = 0
     pending_team_edits: int = 0
     pending_transfers: int = 0
+    pending_player_name_changes: int = 0
 
 @dataclass
 class UserPlayer:

--- a/src/frontend/src/lib/components/ModPanel.svelte
+++ b/src/frontend/src/lib/components/ModPanel.svelte
@@ -17,7 +17,7 @@
     user_info = value;
     let mod_notifs = value.mod_notifications
     if(mod_notifs) {
-      unread_count = mod_notifs.pending_teams + mod_notifs.pending_team_edits + mod_notifs.pending_transfers;
+      unread_count = mod_notifs.pending_teams + mod_notifs.pending_team_edits + mod_notifs.pending_transfers + mod_notifs.pending_player_name_changes;
     }
   });
 
@@ -70,6 +70,14 @@
   {#if check_permission(user_info, permissions.ban_player)}
     <DropdownItem href="/{$page.params.lang}/moderator/player_bans">
       Player Bans
+    </DropdownItem>
+  {/if}
+  {#if check_permission(user_info, permissions.edit_player)}
+    <DropdownItem href="/{$page.params.lang}/moderator/approve_player_names">
+      Player Name Changes
+      {#if user_info.mod_notifications?.pending_player_name_changes}
+        <AlertCount count={user_info.mod_notifications.pending_player_name_changes}/>
+      {/if}
     </DropdownItem>
   {/if}
 </Dropdown>

--- a/src/frontend/src/lib/components/NavBar.svelte
+++ b/src/frontend/src/lib/components/NavBar.svelte
@@ -79,6 +79,8 @@
         </div>
         <Dropdown>
           <DropdownItem href="/{$page.params.lang}/registry/players/profile?id={user_info.player_id}">{$LL.NAVBAR.PROFILE()}</DropdownItem>
+          <DropdownItem href="/{$page.params.lang}/registry/players/edit-profile">Edit Profile</DropdownItem>
+          <DropdownItem href="/{$page.params.lang}/registry/invites">Invites</DropdownItem>
           <DropdownItem on:click={logout}>{$LL.LOGOUT()}</DropdownItem>
         </Dropdown>
       {:else if user_info.id !== null}

--- a/src/frontend/src/lib/components/common/FriendCodeDisplay.svelte
+++ b/src/frontend/src/lib/components/common/FriendCodeDisplay.svelte
@@ -8,12 +8,11 @@
 
     // we want to display the selected FC if there is one, otherwise just display the first FC in the list
     function get_display_fc() {
-        if(!friend_codes.length) {
-            return null;
-        }
         let fc = friend_codes.find((fc) => fc.id === selected_fc_id);
         if(!fc) {
-            fc = friend_codes[0];
+            let filtered_fcs = friend_codes.filter((fc) => fc.is_active);
+            if(!filtered_fcs.length) return null;
+            fc = filtered_fcs[0];
         }
         return fc;
     }
@@ -22,9 +21,9 @@
 
     function get_other_fcs() {
         if(!selected_fc_id) {
-            return friend_codes;
+            return friend_codes.filter((fc) => fc.is_active);
         }
-        return friend_codes.filter((fc) => fc !== display_fc);
+        return friend_codes.filter((fc) => fc !== display_fc && fc.is_active);
     }
 
     let other_fcs = get_other_fcs();

--- a/src/frontend/src/lib/components/registry/players/EditFriendCodes.svelte
+++ b/src/frontend/src/lib/components/registry/players/EditFriendCodes.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+    import type { PlayerInfo } from "$lib/types/player-info";
+    import GameBadge from "$lib/components/badges/GameBadge.svelte";
+    import Dialog from '$lib/components/common/Dialog.svelte';
+    import Button from "$lib/components/common/buttons/Button.svelte";
+    import FriendCodeForm from "./FriendCodeForm.svelte";
+    import LL from "$i18n/i18n-svelte";
+    import { EditSolid } from "flowbite-svelte-icons";
+    import type { FriendCode } from "$lib/types/friend-code";
+
+    export let player: PlayerInfo;
+    export let is_privileged = false;
+
+    let add_fc_dialog: Dialog;
+    let edit_fc_dialog: Dialog;
+    let selected_fc: FriendCode;
+
+    let friend_codes = is_privileged ? player.friend_codes : player.friend_codes.filter((f) => f.is_active);
+
+    function open_edit_dialog(fc: FriendCode) {
+        selected_fc = fc;
+        edit_fc_dialog.open();
+        console.log(is_privileged);
+    }
+
+    async function edit_fc_privileged(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+        const data = new FormData(event.currentTarget);
+        console.log(data.get('is_primary'));
+        const payload = {
+            player_id: player.id,
+            id: selected_fc?.id,
+            fc: data.get('fc')?.toString(),
+            is_primary: data.get('is_primary') ? true : false,
+            description: data.get('description')?.toString(),
+            is_active: data.get('is_active') ? true : false,
+        };
+        console.log(payload);
+        const endpoint = '/api/registry/forceEditFriendCode';
+        const response = await fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        const result = await response.json();
+
+        if (response.status < 300) {
+            window.location.reload();
+        } else {
+            alert(`Editing friend code failed: ${result['title']}`);
+        }
+    }
+
+    async function edit_fc(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+        const data = new FormData(event.currentTarget);
+        const payload = {
+            id: selected_fc?.id,
+            is_primary: data.get('is_primary') ? true : false,
+            description: data.get('description')?.toString(),
+        };
+        console.log(payload);
+        const endpoint = '/api/registry/editFriendCode';
+        const response = await fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        const result = await response.json();
+
+        if (response.status < 300) {
+            window.location.reload();
+        } else {
+            alert(`Editing friend code failed: ${result['title']}`);
+        }
+    }
+</script>
+
+{#each friend_codes as fc}
+    <div class="flex">
+        <GameBadge game={fc.game}/>
+        {fc.fc}
+        {#if !fc.is_active}
+            (inactive)
+        {/if}
+        {#if is_privileged}
+            <EditSolid on:click={() => open_edit_dialog(fc)}/>
+        {/if}
+    </div>
+{/each}
+<div class="button">
+    <Button on:click={add_fc_dialog.open}>{$LL.PLAYER_PROFILE.ADD_FRIEND_CODE()}</Button>
+</div>
+
+<Dialog bind:this={add_fc_dialog} header={$LL.PLAYER_PROFILE.ADD_FRIEND_CODE()}>
+    <FriendCodeForm {player} {is_privileged}/>
+</Dialog>
+
+<Dialog bind:this={edit_fc_dialog} header="Edit Friend Code">
+    {#if selected_fc}
+        <form method="post" on:submit|preventDefault={is_privileged ? edit_fc_privileged : edit_fc}>
+            <div>
+                <div class="option">
+                    <div>
+                        <label for="fc">{$LL.PLAYER_PROFILE.FRIEND_CODE()}</label>
+                    </div>
+                    <div>
+                        <input name="fc" placeholder={selected_fc.game !== 'mk8' ? '0000-0000-0000' : 'NNID'} 
+                        minlength={selected_fc.game === 'mk8' ? 6 : null} maxlength={selected_fc.game === 'mk8' ? 16 : null} 
+                        disabled={!is_privileged} value={selected_fc.fc} required/>
+                    </div>
+                </div>
+                <div class="option">
+                    <div>
+                        <label for="is_primary">{$LL.PLAYER_PROFILE.PRIMARY()}</label>
+                    </div>
+                    <div>
+                        <input name="is_primary" type="checkbox" checked={selected_fc.is_primary}/>
+                    </div>
+                </div>
+                <div class="option">
+                    <div>
+                        <label for="description">{$LL.PLAYER_PROFILE.DESCRIPTION()}</label>
+                    </div>
+                    <div>
+                        <input name="description" placeholder={$LL.PLAYER_PROFILE.DESCRIPTION()} />
+                    </div>
+                </div>
+                {#if is_privileged}
+                    <div class="option">
+                        <div>
+                            <label for="is_active">Active?</label>
+                        </div>
+                        <div>
+                            <input name="is_active" type="checkbox" checked={selected_fc.is_active}/>
+                        </div>
+                    </div>
+                {/if}
+                <Button type="submit">Edit</Button>
+            </div>
+        </form>
+    {/if}
+</Dialog>
+
+<style>
+    div.button {
+      margin-top: 20px;
+    }
+    div.flex {
+        display: flex;
+        gap: 5px;
+    }
+    .option {
+        margin-bottom: 10px;
+        display: flex;
+        align-items: center;
+    }
+  </style>

--- a/src/frontend/src/lib/components/registry/players/EditPlayerDetails.svelte
+++ b/src/frontend/src/lib/components/registry/players/EditPlayerDetails.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+    import Button from "$lib/components/common/buttons/Button.svelte";
+    import CountrySelect from "$lib/components/common/CountrySelect.svelte";
+    import type { PlayerInfo } from "$lib/types/player-info";
+
+    export let player: PlayerInfo;
+    export let is_privileged = false;
+
+    let pending_change = player.name_changes.find((n) => n.approval_status === 'pending');
+
+    async function requestNameChange(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+        const data = new FormData(event.currentTarget);
+        const payload = {
+            name: data.get('name')?.toString(),
+        };
+        console.log(payload);
+        const endpoint = '/api/registry/players/requestName';
+        const response = await fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        const result = await response.json();
+
+        if (response.status < 300) {
+            window.location.reload();
+        } else {
+            alert(`Requesting name change failed: ${result['title']}`);
+        }
+    }
+
+    async function forceEditPlayer(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+        const data = new FormData(event.currentTarget);
+        const payload = {
+            player_id: player.id,
+            name: data.get('name')?.toString(),
+            country_code: data.get('country')?.toString(),
+            is_hidden: data.get('is_hidden') === 'true',
+            is_shadow: player.is_shadow
+        };
+        console.log(payload);
+        const endpoint = '/api/registry/players/edit';
+        const response = await fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        const result = await response.json();
+
+        if (response.status < 300) {
+            window.location.reload();
+        } else {
+            alert(`Editing player failed: ${result['title']}`);
+        }
+    }
+</script>
+
+{#if !is_privileged}
+    {#if !pending_change}
+        <form method="POST" on:submit|preventDefault={requestNameChange}>
+            <div class="option">
+                <label for="name">Name</label>
+                <input name="name" value={player.name} required/>
+            </div>
+            <Button type="submit">Request Name Change</Button>
+        </form>
+    {:else}
+        <div class="bold">
+            Pending name change
+        </div>
+        <div>
+            {player.name} -&gt; {pending_change.name}
+        </div>
+    {/if}
+{:else}
+    <form method="POST" on:submit|preventDefault={forceEditPlayer}>
+        <div class="option">
+            <label for="name">Display Name</label>
+            <input name="name" value={player.name} required/>
+        </div>
+        <div class="option">
+            <label for="country">Country</label>
+            <CountrySelect value={player.country_code} is_required={true}/>
+        </div>
+        <div class="option">
+            <label for="is_hidden">Show on player list?</label>
+            <select name="is_hidden" value={player.is_hidden} required>
+                <option value={false}>Show</option>
+                <option value={true}>Hide</option>
+            </select>
+        </div>
+        <Button type="submit">Edit</Button>
+    </form>
+{/if}
+
+<style>
+    label {
+        display: inline-block;
+        width: 150px;
+        margin-right: 10px;
+    }
+    .option {
+        margin-bottom: 10px;
+        display: flex;
+        align-items: center;
+    }
+    .bold {
+        font-weight: bold;
+    }
+</style>

--- a/src/frontend/src/lib/components/registry/players/FriendCodeForm.svelte
+++ b/src/frontend/src/lib/components/registry/players/FriendCodeForm.svelte
@@ -15,7 +15,7 @@
         if(!player || is_privileged) return [];
         // get all games where we have reached the FC limit
         let maxed_games = Object.keys(fc_limits).filter(
-            (game) => player.friend_codes.filter((fc) => fc.game === game).length >= fc_limits[game]
+            (game) => player.friend_codes.filter((fc) => fc.game === game && fc.is_active).length >= fc_limits[game]
         );
         maxed_games.push('smk'); // smk is on switch so should use mk8dx fcs for that
         console.log(maxed_games);

--- a/src/frontend/src/lib/components/registry/players/PlayerList.svelte
+++ b/src/frontend/src/lib/components/registry/players/PlayerList.svelte
@@ -4,26 +4,19 @@
   import Table from '$lib/components/common/Table.svelte';
   import { page } from '$app/stores';
   import Flag from '$lib/components/common/Flag.svelte';
+  import FriendCodeDisplay from '$lib/components/common/FriendCodeDisplay.svelte';
   export let players: PlayerInfo[];
 </script>
 
 <Table>
   <col class="country_code" />
   <col class="name" />
-  <col class="mk8dx mobile-hide" />
-  <col class="mkw mobile-hide" />
-  <col class="mkt mobile-hide" />
-  <col class="mk7 mobile-hide" />
-  <col class="mk8 mobile-hide" />
+  <col class="friend_codes mobile-hide"/>
   <thead>
     <tr>
       <th></th>
       <th>{$LL.PLAYER_LIST.HEADER.NAME()}</th>
-      <th class="mobile-hide">Switch FC</th>
-      <th class="mobile-hide">MKW FC</th>
-      <th class="mobile-hide">MKT FC</th>
-      <th class="mobile-hide">3DS FC</th>
-      <th class="mobile-hide">NNID</th>
+      <th class="mobile-hide">Friend Codes</th>
     </tr>
   </thead>
   <tbody>
@@ -33,40 +26,23 @@
         <td>
           <a href="/{$page.params.lang}/registry/players/profile?id={player.id}" class={player.is_banned ? 'banned_name' : ''}>{player.name}</a>
         </td>
-        <td class="mobile-hide"
-          >{#each player.friend_codes.filter((fc) => fc.game === "mk8dx") as friend_code}{friend_code.fc}{/each}</td
-        >
-        <td class="mobile-hide"
-          >{#each player.friend_codes.filter((fc) => fc.game === "mkw") as friend_code}{friend_code.fc}{/each}</td
-        >
-        <td class="mobile-hide"
-          >{#each player.friend_codes.filter((fc) => fc.game === "mkt") as friend_code}{friend_code.fc}{/each}</td
-        >
-        <td class="mobile-hide"
-          >{#each player.friend_codes.filter((fc) => fc.game === "mk7") as friend_code}{friend_code.fc}{/each}</td
-        >
-        <td class="mobile-hide"
-          >{#each player.friend_codes.filter((fc) => fc.game === "mk8") as friend_code}{friend_code.fc}{/each}</td
-        >
+        <td class="mobile-hide">
+          <FriendCodeDisplay friend_codes={player.friend_codes}/>
+        </td>
       </tr>
     {/each}
   </tbody>
-  
 </Table>
 
 <style>
   col.country_code {
-    width: 10%;
+    width: 20%;
   }
   col.name {
-    width: 15%;
+    width: 40%;
   }
-  col.mk8dx,
-  col.mkw,
-  col.mkt,
-  col.mk7,
-  col.mk8 {
-    width: 15%;
+  col.friend_codes {
+    width: 40%;
   }
   .banned_name {
     opacity: 0.7;

--- a/src/frontend/src/lib/components/registry/players/PlayerProfile.svelte
+++ b/src/frontend/src/lib/components/registry/players/PlayerProfile.svelte
@@ -51,7 +51,7 @@
       {#if player.friend_codes.length > 0}
         <div class="item">
           <b>{$LL.PLAYER_PROFILE.FRIEND_CODES()}:</b>
-          {#each player.friend_codes as fc}
+          {#each player.friend_codes.filter((f) => f.is_active) as fc}
             <div>
               <GameBadge game={fc.game}/>
               {fc.fc}

--- a/src/frontend/src/lib/components/registry/players/PlayerProfileEdit.svelte
+++ b/src/frontend/src/lib/components/registry/players/PlayerProfileEdit.svelte
@@ -3,20 +3,17 @@
     import LL from '$i18n/i18n-svelte';
     import LanguageSelect from '$lib/components/common/LanguageSelect.svelte';
     import Section from '$lib/components/common/Section.svelte';
-    // import GameBadge from '$lib/components/badges/GameBadge.svelte';
     import Button from '$lib/components/common/buttons/Button.svelte';
-    // import Dialog from '$lib/components/common/Dialog.svelte';
-    // import FriendCodeForm from '$lib/components/registry/players/FriendCodeForm.svelte';
     import LinkDiscord from '$lib/components/common/discord/LinkDiscord.svelte';
     import { check_permission, permissions } from '$lib/util/permissions';
     import type { PlayerInfo } from '$lib/types/player-info';
     import { user } from '$lib/stores/stores';
     import type { UserInfo } from '$lib/types/user-info';
     import EditFriendCodes from './EditFriendCodes.svelte';
+    import EditPlayerDetails from './EditPlayerDetails.svelte';
 
     export let player: PlayerInfo;
 
-    // let fc_dialog: Dialog;
     let user_info: UserInfo;
 
     user.subscribe((value) => {
@@ -47,28 +44,48 @@
             alert(`Editing profile failed: ${result['title']}`);
         }
     }
+
+    async function forceEditProfile(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+        const data = new FormData(event.currentTarget);
+        const payload = {
+            player_id: player.id,
+            avatar: data.get('avatar_url')?.toString(),
+            about_me: data.get('about_me')?.toString(),
+            language: data.get('language')?.toString(),
+            color_scheme: 'light',
+            timezone: 'utc'
+        };
+        const endpoint = '/api/user/settings/forceEdit';
+        const response = await fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        const result = await response.json();
+
+        if (response.status < 300) {
+            window.location.reload();
+            alert('Edited profile successfully');
+        } else {
+            alert(`Editing profile failed: ${result['title']}`);
+        }
+    }
 </script>
 
-{#if player}
-  <Section header={$LL.PLAYER_PROFILE.PLAYER_PROFILE()}>
+<Section header={$LL.PLAYER_PROFILE.PLAYER_PROFILE()}>
     <div slot="header_content">
-      <Button href="/{$page.params.lang}/registry/players/profile?id={player.id}">Back to Profile</Button>
+        <Button href="/{$page.params.lang}/registry/players/profile?id={player.id}">Back to Profile</Button>
     </div>
-  </Section>
-{/if}
-
-<Section header={$LL.PLAYER_PROFILE.FRIEND_CODES()}>
-    <!-- {#each player.friend_codes as fc}
-      <div>
-        <GameBadge game={fc.game}/>
-        {fc.fc}
-      </div>
-    {/each}
-    <div class="button">
-        <Button on:click={fc_dialog.open}>{$LL.PLAYER_PROFILE.ADD_FRIEND_CODE()}</Button>
-    </div> -->
-    <EditFriendCodes {player} is_privileged={check_permission(user_info, permissions.edit_player)}/>
 </Section>
+
+{#if check_permission(user_info, permissions.edit_profile, true)}
+    <Section header="Player Details">
+        <EditPlayerDetails {player} is_privileged={check_permission(user_info, permissions.edit_player)}/>
+    </Section>
+    <Section header={$LL.PLAYER_PROFILE.FRIEND_CODES()}>
+        <EditFriendCodes {player} is_privileged={check_permission(user_info, permissions.edit_player)}/>
+    </Section>
+{/if}
 
 {#if player.id === user_info.player?.id}
     <Section header="Discord">
@@ -78,7 +95,7 @@
 
 <Section header="Edit Profile">
   {#if player.user_settings}
-    <form method="post" on:submit|preventDefault={editProfile}>
+    <form method="post" on:submit|preventDefault={user_info.player?.id === player.id ? editProfile : forceEditProfile}>
       <div>
         <label for="avatar_url">{$LL.PLAYER_PROFILE.AVATAR_URL()}</label>
         <br />
@@ -101,10 +118,6 @@
   {/if}
 </Section>
 
-<!-- <Dialog bind:this={fc_dialog} header={$LL.PLAYER_PROFILE.ADD_FRIEND_CODE()}>
-  <FriendCodeForm {player}/>
-</Dialog> -->
-  
 <style>
   div.button {
     margin-top: 20px;

--- a/src/frontend/src/lib/components/registry/players/PlayerProfileEdit.svelte
+++ b/src/frontend/src/lib/components/registry/players/PlayerProfileEdit.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+    import { page } from '$app/stores';
+    import LL from '$i18n/i18n-svelte';
+    import LanguageSelect from '$lib/components/common/LanguageSelect.svelte';
+    import Section from '$lib/components/common/Section.svelte';
+    // import GameBadge from '$lib/components/badges/GameBadge.svelte';
+    import Button from '$lib/components/common/buttons/Button.svelte';
+    // import Dialog from '$lib/components/common/Dialog.svelte';
+    // import FriendCodeForm from '$lib/components/registry/players/FriendCodeForm.svelte';
+    import LinkDiscord from '$lib/components/common/discord/LinkDiscord.svelte';
+    import { check_permission, permissions } from '$lib/util/permissions';
+    import type { PlayerInfo } from '$lib/types/player-info';
+    import { user } from '$lib/stores/stores';
+    import type { UserInfo } from '$lib/types/user-info';
+    import EditFriendCodes from './EditFriendCodes.svelte';
+
+    export let player: PlayerInfo;
+
+    // let fc_dialog: Dialog;
+    let user_info: UserInfo;
+
+    user.subscribe((value) => {
+        user_info = value;
+    });
+
+    async function editProfile(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+        const data = new FormData(event.currentTarget);
+        const payload = {
+            avatar: data.get('avatar_url')?.toString(),
+            about_me: data.get('about_me')?.toString(),
+            language: data.get('language')?.toString(),
+            color_scheme: 'light',
+            timezone: 'utc'
+        };
+        const endpoint = '/api/user/settings/edit';
+        const response = await fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        const result = await response.json();
+
+        if (response.status < 300) {
+            window.location.reload();
+            alert('Edited profile successfully');
+        } else {
+            alert(`Editing profile failed: ${result['title']}`);
+        }
+    }
+</script>
+
+{#if player}
+  <Section header={$LL.PLAYER_PROFILE.PLAYER_PROFILE()}>
+    <div slot="header_content">
+      <Button href="/{$page.params.lang}/registry/players/profile?id={player.id}">Back to Profile</Button>
+    </div>
+  </Section>
+{/if}
+
+<Section header={$LL.PLAYER_PROFILE.FRIEND_CODES()}>
+    <!-- {#each player.friend_codes as fc}
+      <div>
+        <GameBadge game={fc.game}/>
+        {fc.fc}
+      </div>
+    {/each}
+    <div class="button">
+        <Button on:click={fc_dialog.open}>{$LL.PLAYER_PROFILE.ADD_FRIEND_CODE()}</Button>
+    </div> -->
+    <EditFriendCodes {player} is_privileged={check_permission(user_info, permissions.edit_player)}/>
+</Section>
+
+{#if player.id === user_info.player?.id}
+    <Section header="Discord">
+        <LinkDiscord/>
+    </Section>
+{/if}
+
+<Section header="Edit Profile">
+  {#if player.user_settings}
+    <form method="post" on:submit|preventDefault={editProfile}>
+      <div>
+        <label for="avatar_url">{$LL.PLAYER_PROFILE.AVATAR_URL()}</label>
+        <br />
+        <input name="avatar_url" type="text" value={player.user_settings?.avatar ? player.user_settings.avatar : ''} />
+      </div>
+      <div>
+        <label for="about_me">{$LL.PLAYER_PROFILE.ABOUT_ME()}</label>
+        <br />
+        <textarea name="about_me">{player.user_settings?.about_me ? player.user_settings.about_me : ''}</textarea>
+      </div>
+      <div>
+        <label for="language">{$LL.PLAYER_PROFILE.LANGUAGE()}</label>
+        <br />
+        <LanguageSelect bind:language={player.user_settings.language}/>
+      </div>
+      <div class="button">
+        <Button type="submit" disabled={!check_permission(user_info, permissions.edit_profile, true)}>{$LL.PLAYER_PROFILE.SAVE()}</Button>
+      </div>
+    </form>
+  {/if}
+</Section>
+
+<!-- <Dialog bind:this={fc_dialog} header={$LL.PLAYER_PROFILE.ADD_FRIEND_CODE()}>
+  <FriendCodeForm {player}/>
+</Dialog> -->
+  
+<style>
+  div.button {
+    margin-top: 20px;
+  }
+</style>

--- a/src/frontend/src/lib/components/tournaments/registration/SoloTournamentFields.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/SoloTournamentFields.svelte
@@ -25,7 +25,7 @@
     
     <select name="selected_fc_id" value={selected_fc_id} required>
       <option value={null} selected disabled>Select a Friend Code...</option>
-      {#each friend_codes as fc}
+      {#each friend_codes.filter((f) => f.is_active) as fc}
         <option value={fc.id}>{fc.fc}</option>
       {/each}
     </select>

--- a/src/frontend/src/lib/types/friend-code.ts
+++ b/src/frontend/src/lib/types/friend-code.ts
@@ -5,4 +5,5 @@ export type FriendCode = {
   is_primary: boolean;
   description: string | null;
   is_verified: boolean;
+  is_active: boolean;
 };

--- a/src/frontend/src/lib/types/player-info.ts
+++ b/src/frontend/src/lib/types/player-info.ts
@@ -9,7 +9,7 @@ type PlayerNameChange = {
   name: string;
   date: number;
   approval_status: string;
-}
+};
 
 export type PlayerInfo = {
   id: number;

--- a/src/frontend/src/lib/types/player-info.ts
+++ b/src/frontend/src/lib/types/player-info.ts
@@ -4,6 +4,13 @@ import type { UserSettings } from '$lib/types/user-settings';
 import type { PlayerRoster } from './player-roster';
 import type { Discord } from './discord';
 
+type PlayerNameChange = {
+  id: number;
+  name: string;
+  date: number;
+  approval_status: string;
+}
+
 export type PlayerInfo = {
   id: number;
   name: string;
@@ -16,4 +23,5 @@ export type PlayerInfo = {
   rosters: PlayerRoster[];
   ban_info: BanInfoBasic | null;
   user_settings: UserSettings | null;
+  name_changes: PlayerNameChange[];
 };

--- a/src/frontend/src/lib/types/player-name-change-request.ts
+++ b/src/frontend/src/lib/types/player-name-change-request.ts
@@ -1,0 +1,9 @@
+export type PlayerNameChangeRequest = {
+    id: number;
+    player_id: number;
+    player_name: string;
+    player_country: string;
+    request_name: string;
+    date: number;
+    approval_status: string;
+}

--- a/src/frontend/src/lib/types/player-name-change-request.ts
+++ b/src/frontend/src/lib/types/player-name-change-request.ts
@@ -1,9 +1,9 @@
 export type PlayerNameChangeRequest = {
-    id: number;
-    player_id: number;
-    player_name: string;
-    player_country: string;
-    request_name: string;
-    date: number;
-    approval_status: string;
-}
+  id: number;
+  player_id: number;
+  player_name: string;
+  player_country: string;
+  request_name: string;
+  date: number;
+  approval_status: string;
+};

--- a/src/frontend/src/lib/types/user-info.ts
+++ b/src/frontend/src/lib/types/user-info.ts
@@ -5,6 +5,7 @@ type ModNotifications = {
   pending_teams: number;
   pending_team_edits: number;
   pending_transfers: number;
+  pending_player_name_changes: number;
 };
 
 type UserRole = {

--- a/src/frontend/src/lib/util/permissions.ts
+++ b/src/frontend/src/lib/util/permissions.ts
@@ -195,4 +195,5 @@ export const mod_panel_permissions = [
   permissions.manage_transfers,
   permissions.ban_player,
   permissions.manage_user_roles,
+  permissions.edit_player,
 ];

--- a/src/frontend/src/routes/[lang]/moderator/approve_player_names/+page.svelte
+++ b/src/frontend/src/routes/[lang]/moderator/approve_player_names/+page.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+    import { onMount } from "svelte";
+    import type { PlayerNameChangeRequest } from "$lib/types/player-name-change-request";
+    import { check_permission, permissions } from "$lib/util/permissions";
+    import type { UserInfo } from '$lib/types/user-info';
+    import { user } from '$lib/stores/stores';
+    import Table from "$lib/components/common/Table.svelte";
+    import { page } from "$app/stores";
+    import ArrowRight from "$lib/components/common/ArrowRight.svelte";
+    import Flag from "$lib/components/common/Flag.svelte";
+    import Section from "$lib/components/common/Section.svelte";
+    import { locale } from "$i18n/i18n-svelte";
+    import ConfirmButton from "$lib/components/common/buttons/ConfirmButton.svelte";
+    import CancelButton from "$lib/components/common/buttons/CancelButton.svelte";
+
+    let name_requests: PlayerNameChangeRequest[] = [];
+
+    let user_info: UserInfo;
+    user.subscribe((value) => {
+        user_info = value;
+    });
+
+    onMount(async () => {
+        const res = await fetch(`/api/registry/players/pendingNameChanges`);
+        if (res.status === 200) {
+            const body: PlayerNameChangeRequest[] = await res.json();
+            name_requests = body;
+        }
+    });
+
+    const options: Intl.DateTimeFormatOptions = {
+        dateStyle: 'short',
+        timeStyle: 'short',
+    };
+
+    async function approveNameRequest(request: PlayerNameChangeRequest) {
+        let conf = window.confirm("Are you sure you wish to approve this name change request?");
+        if(!conf) return;
+        const payload = {
+            request_id: request.id,
+        };
+        const res = await fetch(`/api/registry/players/approveNameChange`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        const result = await res.json();
+        if (res.status < 300) {
+            window.location.reload();
+        } else {
+            alert(`Name edit failed: ${result['title']}`);
+        }
+    }
+
+    async function denyNameRequest(request: PlayerNameChangeRequest) {
+        let conf = window.confirm("Are you sure you wish to deny this name change request?");
+        if(!conf) return;
+        const payload = {
+            request_id: request.id,
+        };
+        const res = await fetch(`/api/registry/players/denyNameChange`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        const result = await res.json();
+        if (res.status < 300) {
+            window.location.reload();
+        } else {
+            alert(`Denying name edit failed: ${result['title']}`);
+        }
+    }
+</script>
+
+{#if name_requests.length && check_permission(user_info, permissions.edit_player)}
+<Section header="Pending Player Name Requests">
+    <Table>
+        <col class="country">
+        <col class="name">
+        <col class="date">
+        <col class="approve">
+        <thead>
+            <tr>
+                <th/>
+                <th>Name</th>
+                <th>Date</th>
+                <th>Approve?</th>
+            </tr>
+        </thead>
+        <tbody>
+            {#each name_requests as r, i}
+                <tr class="row-{i % 2}">
+                    <td>
+                        <Flag country_code={r.player_country}/>
+                    </td>
+                    <td>
+                        <a href="/{$page.params.lang}/registry/players/profile?id={r.player_id}">
+                            <div class="flex">
+                                {r.player_name}
+                                <ArrowRight/>
+                                {r.request_name}
+                            </div>
+                        </a>
+                    </td>
+                    <td>
+                        {new Date(r.date * 1000).toLocaleString($locale, options)}
+                    </td>
+                    <td>
+                        <ConfirmButton on:click={() => approveNameRequest(r)}/>
+                        <CancelButton on:click={() => denyNameRequest(r)}/>
+                      </td>
+                </tr>
+            {/each}
+        </tbody>
+    </Table>
+</Section>
+{/if}
+
+<style>
+    .flex {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: 10px;
+    }
+    col.country {
+        width: 10%;
+    }
+    col.name {
+      width: 40%;
+    }
+    col.date {
+      width: 25%;
+    }
+    col.approve {
+      width: 25%;
+    }
+  </style>

--- a/src/frontend/src/routes/[lang]/moderator/approve_team_edits/+page.svelte
+++ b/src/frontend/src/routes/[lang]/moderator/approve_team_edits/+page.svelte
@@ -7,7 +7,6 @@
   import { check_permission, permissions } from '$lib/util/permissions';
   import { locale } from '$i18n/i18n-svelte';
   import { page } from '$app/stores';
-  import { goto } from '$app/navigation';
   import TagBadge from '$lib/components/badges/TagBadge.svelte';
   import ArrowRight from '$lib/components/common/ArrowRight.svelte';
   import ConfirmButton from '$lib/components/common/buttons/ConfirmButton.svelte';
@@ -94,7 +93,7 @@
     const result = await res.json();
     if (res.status < 300) {
       alert('Successfully approved roster profile change');
-      goto(`/${$page.params.lang}/registry/teams`);
+      window.location.reload();
     } else {
       alert(`Team edit failed: ${result['title']}`);
     }
@@ -114,7 +113,7 @@
     const result = await res.json();
     if (res.status < 300) {
       alert('Successfully denied roster profile change');
-      goto(`/${$page.params.lang}/registry/teams`);
+      window.location.reload();
     } else {
       alert(`Failed: ${result['title']}`);
     }

--- a/src/frontend/src/routes/[lang]/registry/players/+page.svelte
+++ b/src/frontend/src/routes/[lang]/registry/players/+page.svelte
@@ -25,7 +25,7 @@
 
   async function fetchData() {
     players = [];
-    let url = '/api/registry/players?detailed=true&is_banned=false';
+    let url = '/api/registry/players?detailed=true&is_banned=false&is_hidden=false';
     if (filters.game != null && filters.game != '') {
       url += '&game=' + filters.game;
     }

--- a/src/frontend/src/routes/[lang]/registry/players/edit-profile/+page.svelte
+++ b/src/frontend/src/routes/[lang]/registry/players/edit-profile/+page.svelte
@@ -1,58 +1,16 @@
 <script lang="ts">
-  import { page } from '$app/stores';
   import { user } from '$lib/stores/stores';
   import type { UserInfo } from '$lib/types/user-info';
-  import type { UserSettings } from '$lib/types/user-settings';
   import LL from '$i18n/i18n-svelte';
-  import LanguageSelect from '$lib/components/common/LanguageSelect.svelte';
-  import Section from '$lib/components/common/Section.svelte';
-  import GameBadge from '$lib/components/badges/GameBadge.svelte';
-  import Button from '$lib/components/common/buttons/Button.svelte';
-  import Dialog from '$lib/components/common/Dialog.svelte';
-  import FriendCodeForm from '$lib/components/registry/players/FriendCodeForm.svelte';
-  import LinkDiscord from '$lib/components/common/discord/LinkDiscord.svelte';
-  import { check_permission, permissions } from '$lib/util/permissions';
+  import PlayerProfileEdit from '$lib/components/registry/players/PlayerProfileEdit.svelte';
 
   let user_info: UserInfo;
-  let user_settings: UserSettings | null;
-  let fc_dialog: Dialog;
-
-  // const color_schemes = ['light', 'dark'];
-  // const timezones = ['utc'];
 
   user.subscribe((value) => {
     user_info = value;
   });
 
   $: player = user_info.player ? user_info.player : null;
-  $: user_settings = player?.user_settings ? player.user_settings : null;
-
-  async function editProfile(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
-    const data = new FormData(event.currentTarget);
-    const payload = {
-      avatar: data.get('avatar_url')?.toString(),
-      about_me: data.get('about_me')?.toString(),
-      language: data.get('language')?.toString(),
-      // color_scheme: data.get('theme')?.toString(),
-      // timezone: data.get('timezone')?.toString(),
-      color_scheme: 'light',
-      timezone: 'utc'
-    };
-    const endpoint = '/api/user/settings/edit';
-    const response = await fetch(endpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    });
-    const result = await response.json();
-
-    if (response.status < 300) {
-      window.location.reload();
-      alert('Edited profile successfully');
-    } else {
-      alert(`Editing profile failed: ${result['title']}`);
-    }
-  }
 </script>
 
 <svelte:head>
@@ -60,83 +18,5 @@
 </svelte:head>
 
 {#if player}
-  <Section header={$LL.PLAYER_PROFILE.PLAYER_PROFILE()}>
-    <div slot="header_content">
-      <Button href="/{$page.params.lang}/registry/players/profile?id={player.id}">Back to Profile</Button>
-    </div>
-  </Section>
+  <PlayerProfileEdit {player}/>
 {/if}
-
-
-<Section header={$LL.PLAYER_PROFILE.FRIEND_CODES()}>
-{#if player}
-    {#each player.friend_codes as fc}
-      <div>
-        <GameBadge game={fc.game}/>
-        {fc.fc}
-      </div>
-    {/each}
-  <div class="button">
-    <Button on:click={fc_dialog.open}>{$LL.PLAYER_PROFILE.ADD_FRIEND_CODE()}</Button>
-  </div>
-{/if}
-</Section>
-
-<Section header="Discord">
-  <LinkDiscord/>
-</Section>
-
-<Section header="Edit Profile">
-{#if user_settings}
-<form method="post" on:submit|preventDefault={editProfile}>
-  <div>
-    <label for="avatar_url">{$LL.PLAYER_PROFILE.AVATAR_URL()}</label>
-    <br />
-    <input name="avatar_url" type="text" value={user_settings?.avatar ? user_settings.avatar : ''} />
-  </div>
-  <div>
-    <label for="about_me">{$LL.PLAYER_PROFILE.ABOUT_ME()}</label>
-    <br />
-    <textarea name="about_me">{user_settings?.about_me ? user_settings.about_me : ''}</textarea>
-  </div>
-  <div>
-    <label for="language">{$LL.PLAYER_PROFILE.LANGUAGE()}</label>
-    <br />
-    <LanguageSelect bind:language={user_settings.language}/>
-  </div>
-  <!-- <div>
-    <label for="theme">{$LL.PLAYER_PROFILE.THEME()}</label>
-    <br />
-    <select name="theme">
-      {#each color_schemes as theme}
-        <option value={theme}>{theme}</option>
-      {/each}
-    </select>
-  </div>
-  <div>
-    <label for="timezone">{$LL.PLAYER_PROFILE.TIMEZONE()}</label>
-    <br />
-    <select name="timezone">
-      {#each timezones as tz}
-        <option value={tz}>{tz}</option>
-      {/each}
-    </select>
-  </div> -->
-  <div class="button">
-    <Button type="submit" disabled={!check_permission(user_info, permissions.edit_profile, true)}>{$LL.PLAYER_PROFILE.SAVE()}</Button>
-  </div>
-  
-</form>
-{/if}
-</Section>
-
-<Dialog bind:this={fc_dialog} header={$LL.PLAYER_PROFILE.ADD_FRIEND_CODE()}>
-  <FriendCodeForm {player}/>
-</Dialog>
-  
-
-<style>
-  div.button {
-    margin-top: 20px;
-  }
-</style>

--- a/src/frontend/src/routes/[lang]/registry/players/mod-edit-profile/+page.svelte
+++ b/src/frontend/src/routes/[lang]/registry/players/mod-edit-profile/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+    import LL from '$i18n/i18n-svelte';
+    import PlayerProfileEdit from '$lib/components/registry/players/PlayerProfileEdit.svelte';
+    import { onMount } from 'svelte';
+    import { page } from '$app/stores';
+    import type { PlayerInfo } from '$lib/types/player-info';
+
+    let player: PlayerInfo;
+
+    onMount(async() => {
+        let param_id = $page.url.searchParams.get('id');
+        let id = Number(param_id);
+        const res = await fetch(`/api/registry/players/${id}`);
+        if (res.status != 200) {
+            return;
+        }
+        const body: PlayerInfo = await res.json();
+        player = body;
+    })
+  </script>
+  
+  <svelte:head>
+    <title>{$LL.PLAYER_PROFILE.EDIT_PROFILE()} | Mario Kart Central</title>
+  </svelte:head>
+  
+  {#if player}
+    <PlayerProfileEdit {player}/>
+  {/if}
+  

--- a/src/frontend/src/routes/[lang]/registry/players/profile/+page.svelte
+++ b/src/frontend/src/routes/[lang]/registry/players/profile/+page.svelte
@@ -63,13 +63,18 @@
     <PlayerProfileBan ban_info={player.ban_info} />
   {/if}
 
-  {#if check_permission(user_info, permissions.ban_player)}
+  {#if check_permission(user_info, permissions.ban_player) || check_permission(user_info, permissions.edit_player)}
     <Section header={$LL.NAVBAR.MODERATOR()}>
       <div slot="header_content">
-        {#if !player.is_banned}
-          <Button on:click={banDialog.open}>{$LL.PLAYER_BAN.BAN_PLAYER()}</Button>
-        {:else}
-          <Button on:click={editBanDialog.open}>{$LL.PLAYER_BAN.VIEW_EDIT_BAN()}</Button>
+        {#if check_permission(user_info, permissions.ban_player)}
+          {#if !player.is_banned}
+            <Button on:click={banDialog.open}>{$LL.PLAYER_BAN.BAN_PLAYER()}</Button>
+          {:else}
+            <Button on:click={editBanDialog.open}>{$LL.PLAYER_BAN.VIEW_EDIT_BAN()}</Button>
+          {/if}
+        {/if}
+        {#if check_permission(user_info, permissions.edit_player)}
+          <Button href="/{$page.params.lang}/registry/players/mod-edit-profile?id={player.id}">Edit Player</Button>
         {/if}
       </div>
     </Section>

--- a/src/frontend/svelte.config.js
+++ b/src/frontend/svelte.config.js
@@ -29,6 +29,7 @@ function getEntriesForLocale(locale) {
     `/${locale}/player-signup`,
     `/${locale}/registry/players`,
     `/${locale}/registry/players/edit-profile`,
+    `/${locale}/registry/players/mod-edit-profile`,
     `/${locale}/registry/players/profile`,
     `/${locale}/registry/invites`,
     `/${locale}/registry/teams`,
@@ -44,6 +45,7 @@ function getEntriesForLocale(locale) {
     `/${locale}/moderator/approve_transfers`,
     `/${locale}/moderator/manage_user_roles`,
     `/${locale}/moderator/player_bans`,
+    `/${locale}/moderator/approve_player_names`,
   ];
 }
 


### PR DESCRIPTION
- Added support for mods adding, editing FCs for players
- Added support for making FCs inactive, thus being able to be claimed by other players and not being selectable for tournaments
- Users with the edit player permission can now edit player details from player profile pages
- Players can now request a name change on the edit profile page
- Mods can approve name changes in the Moderator tab
- Added Edit Profile and Invites to the drop-down when clicking your username in the navbar