### PR TITLE
Add some suggestions from beta test

### DIFF
--- a/src/backend/common/data/commands/players/players.py
+++ b/src/backend/common/data/commands/players/players.py
@@ -160,10 +160,11 @@ class GetPlayerDetailedCommand(Command[PlayerDetailed | None]):
             user_settings = None
             if user:
                 async with db.execute("""SELECT avatar, about_me, language, 
-                    color_scheme, timezone FROM user_settings WHERE user_id = ?""", (user.id,)) as cursor:
+                    color_scheme, timezone, hide_discord FROM user_settings WHERE user_id = ?""", (user.id,)) as cursor:
                     settings_row = await cursor.fetchone()
                     if settings_row is not None:
-                        user_settings = UserSettings(user.id, *settings_row)
+                        avatar, about_me, language, color_scheme, timezone, hide_discord = settings_row
+                        user_settings = UserSettings(user.id, avatar, about_me, language, color_scheme, timezone, bool(hide_discord))
 
             discord = None
             if user:

--- a/src/backend/common/data/commands/teams/teams.py
+++ b/src/backend/common/data/commands/teams/teams.py
@@ -466,6 +466,10 @@ class ListTeamsCommand(Command[TeamList]):
                     where_clauses.append(f"(t.{column_name} LIKE ? OR r.{column_name} LIKE ?)")
                     variable_parameters.extend([f"%{filter_value}%", f"%{filter_value}%"])
 
+            if filter.name_or_tag is not None:
+                where_clauses.append("(t.name LIKE ? OR t.tag LIKE ? OR r.name LIKE ? OR r.tag LIKE ?)")
+                variable_parameters.extend([f"%{filter.name_or_tag}%"]*4)
+
             append_team_roster_like_filter(filter.name, "name")
             append_team_roster_like_filter(filter.tag, "tag")
             append_equal_filter(filter.game, "r.game")

--- a/src/backend/common/data/db/tables.py
+++ b/src/backend/common/data/db/tables.py
@@ -800,6 +800,7 @@ class UserSettings(TableModel):
     language: str
     color_scheme: str
     timezone: str
+    hide_discord: bool
 
     @staticmethod
     def get_create_table_command() -> str:
@@ -809,7 +810,8 @@ class UserSettings(TableModel):
             about_me TEXT,
             language TEXT DEFAULT 'en-us' NOT NULL,
             color_scheme TEXT DEFAULT 'light' NOT NULL,
-            timezone TEXT DEFAULT 'UTC' NOT NULL
+            timezone TEXT DEFAULT 'UTC' NOT NULL,
+            hide_discord BOOLEAN DEFAULT FALSE
             ) WITHOUT ROWID"""
 
 @dataclass

--- a/src/backend/common/data/models/teams.py
+++ b/src/backend/common/data/models/teams.py
@@ -283,6 +283,7 @@ class KickPlayerRequestData():
 class TeamFilter():
     name: str | None = None
     tag: str | None = None
+    name_or_tag: str | None = None
     game: Game | None = None
     mode: GameMode | None = None
     language: str | None = None

--- a/src/backend/common/data/models/user_settings.py
+++ b/src/backend/common/data/models/user_settings.py
@@ -10,6 +10,7 @@ class UserSettings:
     language: str = 'en-us'
     color_scheme: str = 'light'
     timezone: str = 'UTC'
+    hide_discord: bool = False
 
 @dataclass
 class EditUserSettingsRequestData:
@@ -18,6 +19,7 @@ class EditUserSettingsRequestData:
     language: Literal['de', 'en-gb', 'en-us', 'es', 'fr', 'ja'] | None = None
     color_scheme: Literal['light', 'dark'] | None = None
     timezone: str | None = None
+    hide_discord: bool | None = None
 
 @dataclass
 class EditPlayerUserSettingsRequestData:
@@ -27,6 +29,7 @@ class EditPlayerUserSettingsRequestData:
     language: Literal['de', 'en-gb', 'en-us', 'es', 'fr', 'ja'] | None = None
     color_scheme: Literal['light', 'dark'] | None = None
     timezone: str | None = None
+    hide_discord: bool | None = None
 
 @dataclass
 class SetLanguageRequestData:

--- a/src/frontend/src/i18n/de/index.ts
+++ b/src/frontend/src/i18n/de/index.ts
@@ -530,6 +530,7 @@ const de: Translation = {
       PLAYER_NOT_FOUND: 'Player not found',
       REGISTRATION_DATE: 'Registered',
       NAME_CHANGE_HISTORY: 'Name Change History',
+      SHOW_DISCORD_INFO: 'Make Discord info publicly visible?',
     },
     SHADOW_PLAYERS: {
       UNCLAIMED_PLAYER_DESCRIPTION:

--- a/src/frontend/src/i18n/en-us/index.ts
+++ b/src/frontend/src/i18n/en-us/index.ts
@@ -527,6 +527,7 @@ const en_us: BaseTranslation = {
       PLAYER_NOT_FOUND: 'Player not found',
       REGISTRATION_DATE: 'Registered',
       NAME_CHANGE_HISTORY: 'Name Change History',
+      SHOW_DISCORD_INFO: 'Make Discord info publicly visible?',
     },
     SHADOW_PLAYERS: {
       UNCLAIMED_PLAYER_DESCRIPTION:

--- a/src/frontend/src/i18n/es/index.ts
+++ b/src/frontend/src/i18n/es/index.ts
@@ -530,6 +530,7 @@ const es: Translation = {
       PLAYER_NOT_FOUND: 'Player not found',
       REGISTRATION_DATE: 'Registered',
       NAME_CHANGE_HISTORY: 'Name Change History',
+      SHOW_DISCORD_INFO: 'Make Discord info publicly visible?',
     },
     SHADOW_PLAYERS: {
       UNCLAIMED_PLAYER_DESCRIPTION:

--- a/src/frontend/src/i18n/fr/index.ts
+++ b/src/frontend/src/i18n/fr/index.ts
@@ -530,6 +530,7 @@ const fr: Translation = {
       PLAYER_NOT_FOUND: 'Le joueur est introuvable',
       REGISTRATION_DATE: 'Registered',
       NAME_CHANGE_HISTORY: 'Name Change History',
+      SHOW_DISCORD_INFO: 'Make Discord info publicly visible?',
     },
     SHADOW_PLAYERS: {
       UNCLAIMED_PLAYER_DESCRIPTION:

--- a/src/frontend/src/i18n/i18n-types.ts
+++ b/src/frontend/src/i18n/i18n-types.ts
@@ -2003,6 +2003,10 @@ type RootTranslation = {
 			 * N​a​m​e​ ​C​h​a​n​g​e​ ​H​i​s​t​o​r​y
 			 */
 			NAME_CHANGE_HISTORY: string
+			/**
+			 * M​a​k​e​ ​D​i​s​c​o​r​d​ ​i​n​f​o​ ​p​u​b​l​i​c​l​y​ ​v​i​s​i​b​l​e​?
+			 */
+			SHOW_DISCORD_INFO: string
 		}
 		SHADOW_PLAYERS: {
 			/**
@@ -6705,6 +6709,10 @@ export type TranslationFunctions = {
 			 * Name Change History
 			 */
 			NAME_CHANGE_HISTORY: () => LocalizedString
+			/**
+			 * Make Discord info publicly visible?
+			 */
+			SHOW_DISCORD_INFO: () => LocalizedString
 		}
 		SHADOW_PLAYERS: {
 			/**

--- a/src/frontend/src/i18n/ja/index.ts
+++ b/src/frontend/src/i18n/ja/index.ts
@@ -529,6 +529,7 @@ const ja: Translation = {
       PLAYER_NOT_FOUND: 'Player not found',
       REGISTRATION_DATE: 'Registered',
       NAME_CHANGE_HISTORY: 'Name Change History',
+      SHOW_DISCORD_INFO: 'Make Discord info publicly visible?',
     },
     SHADOW_PLAYERS: {
       UNCLAIMED_PLAYER_DESCRIPTION:

--- a/src/frontend/src/lib/components/common/PlayerSearch.svelte
+++ b/src/frontend/src/lib/components/common/PlayerSearch.svelte
@@ -134,7 +134,7 @@
     z-index: 1;
   }
   div.table-inner {
-    max-height: 100px;
+    max-height: 150px;
     overflow-y: scroll;
   }
   tr {

--- a/src/frontend/src/lib/components/common/RoleInfo.svelte
+++ b/src/frontend/src/lib/components/common/RoleInfo.svelte
@@ -164,7 +164,7 @@
         flex-direction: column;
     }
     div.addplayer {
-        min-width: 300px;
+        min-width: 350px;
         display: flex;
         gap: 10px;
     }

--- a/src/frontend/src/lib/components/homepage/RecentTransactions.svelte
+++ b/src/frontend/src/lib/components/homepage/RecentTransactions.svelte
@@ -50,8 +50,8 @@
                             </a>
                         </div>
                         <div class="badges">
-                            <GameBadge game={transfer.game} style='font-size: 0.95rem; width: 85px;' />
-                            <ModeBadge mode={transfer.mode} style='font-size: 0.95rem; width: 85px;' />
+                            <GameBadge game={transfer.game}/>
+                            <ModeBadge mode={transfer.mode}/>
                         </div>
                     </div>
                     <div class="right">
@@ -96,9 +96,10 @@
     .right {
         display: flex;
         align-items: center;
+        margin-top: auto;
         gap: 5px;
     }
     .badges {
-        zoom: 85%;
+        zoom: 90%;
     }
 </style>

--- a/src/frontend/src/lib/components/registry/players/PlayerProfile.svelte
+++ b/src/frontend/src/lib/components/registry/players/PlayerProfile.svelte
@@ -17,6 +17,7 @@
   import FCTypeBadge from '$lib/components/badges/FCTypeBadge.svelte';
   import RoleBadge from '$lib/components/badges/RoleBadge.svelte';
   import PlayerNameHistory from '$lib/components/registry/players/PlayerNameHistory.svelte';
+  import { permissions, check_permission } from '$lib/util/permissions';
 
   let user_info: UserInfo;
 
@@ -109,12 +110,13 @@
               </div>
             {/each}
           </div>
-          
         </div>
       {/if}
-      <div class="item centered" style="grid-area: g;">
-        <DiscordDisplay discord={player.discord}/>
-      </div>
+      {#if !player.user_settings || !player.user_settings.hide_discord || check_permission(user_info, permissions.edit_player)}
+        <div class="item centered" style="grid-area: g;">
+          <DiscordDisplay discord={player.discord}/>
+        </div>
+      {/if}
       {#if player.user_settings && player.user_settings.about_me}
         <div class="about_me" style="grid-area: h;">
             {player.user_settings.about_me}

--- a/src/frontend/src/lib/components/registry/players/PlayerProfileEdit.svelte
+++ b/src/frontend/src/lib/components/registry/players/PlayerProfileEdit.svelte
@@ -28,7 +28,8 @@
             about_me: data.get('about_me')?.toString(),
             language: data.get('language')?.toString(),
             color_scheme: 'light',
-            timezone: 'utc'
+            timezone: 'utc',
+            hide_discord: data.get('hide_discord') === "true",
         };
         const endpoint = '/api/user/settings/edit';
         const response = await fetch(endpoint, {
@@ -54,7 +55,8 @@
             about_me: data.get('about_me')?.toString(),
             language: data.get('language')?.toString(),
             color_scheme: 'light',
-            timezone: 'utc'
+            timezone: 'utc',
+            hide_discord: data.get('hide_discord') === "true",
         };
         const endpoint = '/api/user/settings/forceEdit';
         const response = await fetch(endpoint, {
@@ -145,19 +147,26 @@
     </Section>
 {/if}
 
-
 <Section header={$LL.PLAYERS.PROFILE.EDIT_PROFILE()}>
   {#if player.user_settings}
     <form method="post" on:submit|preventDefault={user_info.player?.id === player.id ? editProfile : forceEditProfile}>
-      <div>
+      <div class="option">
         <label for="about_me">{$LL.PLAYERS.PROFILE.ABOUT_ME()}</label>
         <br />
         <textarea name="about_me" maxlength=200>{player.user_settings?.about_me ? player.user_settings.about_me : ''}</textarea>
       </div>
-      <div>
+      <div class="option">
         <label for="language">{$LL.COMMON.LANGUAGE()}</label>
         <br />
         <LanguageSelect bind:language={player.user_settings.language}/>
+      </div>
+      <div class="option">
+        <label for="hide_discord">{$LL.PLAYERS.PROFILE.SHOW_DISCORD_INFO()}</label>
+        <br/>
+        <select name="hide_discord" bind:value={player.user_settings.hide_discord}>
+            <option value={false}>{$LL.COMMON.SHOW()}</option>
+            <option value={true}>{$LL.COMMON.HIDE()}</option>
+        </select>
       </div>
       <div class="button">
         <Button type="submit" disabled={!check_permission(user_info, permissions.edit_profile, true)}>{$LL.COMMON.SAVE()}</Button>
@@ -173,5 +182,11 @@
   textarea {
     width: 100%;
     height: 150px;
+  }
+  label {
+    width: max-content;
+  }
+  div.option {
+    margin-bottom: 10px;
   }
 </style>

--- a/src/frontend/src/lib/components/registry/teams/TeamList.svelte
+++ b/src/frontend/src/lib/components/registry/teams/TeamList.svelte
@@ -32,7 +32,7 @@
   type TeamFilter = {
     game: string | null;
     mode: string | null;
-    name: string | null;
+    name_or_tag: string | null;
     is_historical: boolean;
     is_active: boolean | null;
     page: number;
@@ -41,7 +41,7 @@
   let filters: TeamFilter = {
     game: null,
     mode: null,
-    name: null,
+    name_or_tag: null,
     is_historical: false,
     is_active: null,
     page: 1,
@@ -86,7 +86,7 @@
       <GameModeSelect all_option hide_labels inline is_team bind:game={filters.game} bind:mode={filters.mode}/>
     </div>
     <div class="option">
-      <input class="search" bind:value={filters.name} type="text" placeholder={$LL.TEAMS.LIST.SEARCH_BY()}/>
+      <input class="search" bind:value={filters.name_or_tag} type="text" placeholder={$LL.TEAMS.LIST.SEARCH_BY()}/>
     </div>
     <div class="option">
       <select bind:value={filters.is_historical}>

--- a/src/frontend/src/lib/components/registry/teams/TransferList.svelte
+++ b/src/frontend/src/lib/components/registry/teams/TransferList.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import type { TeamTransfer, TransferList } from "$lib/types/team-transfer";
     import Dialog from "$lib/components/common/Dialog.svelte";
-    import Table from "$lib/components/common/Table.svelte";
     import { onMount } from "svelte";
     import { locale } from "$i18n/i18n-svelte";
     import Flag from "$lib/components/common/Flag.svelte";
@@ -132,7 +131,7 @@
 
 
 <form on:submit|preventDefault={search}>
-    <div class="flex">
+    <div class="top">
         {#if !team_id}
             <GameModeSelect bind:game={game} bind:mode={mode} flex all_option hide_labels inline is_team/>
         {/if}
@@ -147,58 +146,37 @@
         <div class="option">
             <Button type="submit">{$LL.COMMON.FILTER()}</Button>
         </div>
-        
     </div>
 </form>
 
 {#if transfers.length}
     <PageNavigation bind:currentPage={page_number} totalPages={total_pages} refresh_function={fetchData}/>
-    <Table>
-        <col class="country"/>
-        <col class="name" />
-        <col class="gamemode mobile-hide"/>
-        <col class="between" />
-        <col class="date mobile-hide" />
-        {#if approval_status === "pending"}
-            <col class="approve" />
-        {/if}
-        <thead>
-        <tr>
-            <th></th>
-            <th>{$LL.COMMON.PLAYER()}</th>
-            <th class="mobile-hide">{$LL.COMMON.GAME_MODE()}</th>
-            <th></th>
-            <th class="mobile-hide">{$LL.COMMON.DATE()}</th>
-            {#if approval_status === "pending"}
-                <th>{$LL.MODERATOR.APPROVE()}</th>
-            {/if}
-        </tr>
-        </thead>
-        <tbody>
-        {#each transfers as transfer, i}
-            <tr class="row-{i % 2}">
-            <td>
-                <Flag country_code={transfer.player_country_code}/>
-            </td>
-            <td>
-                <a href="/{$page.params.lang}/registry/players/profile?id={transfer.player_id}">
-                    {transfer.player_name}
-                    {#if transfer.is_bagger_clause}
-                        <BaggerBadge/>
-                    {/if}
-                </a>
-            </td>
-            <td class="mobile-hide">
-                <GameBadge game={transfer.game}/>
-                <ModeBadge mode={transfer.mode}/>
-            </td>
-            <td>
-                <div class="flex">
+    <div class="transfers">
+        {#each transfers as transfer}
+            <div class="row">
+                <div class="date field">
+                    {new Date(transfer.date * 1000).toLocaleString($locale, options)}
+                </div>
+                <div class="left field">
+                    <div class="flag">
+                        <Flag country_code={transfer.player_country_code}/>
+                    </div>
+                    <a href="/{$page.params.lang}/registry/players/profile?id={transfer.player_id}">
+                        {transfer.player_name}
+                        {#if transfer.is_bagger_clause}
+                            <BaggerBadge/>
+                        {/if}
+                    </a>
+                </div>
+                <div class="badges field">
+                    <GameBadge game={transfer.game}/>
+                    <ModeBadge mode={transfer.mode}/>
+                </div>
+                <div class="right field">
                     {#if transfer.roster_leave}
                         <a href="/{$page.params.lang}/registry/teams/profile?id={transfer.roster_leave.team_id}">
                             <TagBadge tag={transfer.roster_leave.roster_tag} color={transfer.roster_leave.team_color}/>
                         </a>
-                        
                     {:else}
                         {$LL.TEAMS.TRANSFERS.NO_TEAM()}
                     {/if}
@@ -211,19 +189,15 @@
                         {$LL.TEAMS.TRANSFERS.NO_TEAM()}
                     {/if}
                 </div>
-                
-            </td>
-            <td class="mobile-hide">{new Date(transfer.date * 1000).toLocaleString($locale, options)}</td>
-            {#if approval_status === "pending"}
-                <td>
-                    <ConfirmButton on:click={() => approveTransfer(transfer)}/>
-                    <CancelButton on:click={() => denyDialog(transfer)}/>
-                </td>
-            {/if}
-            </tr>
+                {#if approval_status === "pending"}
+                    <div class="approve field">
+                        <ConfirmButton on:click={() => approveTransfer(transfer)}/>
+                        <CancelButton on:click={() => denyDialog(transfer)}/>
+                    </div>
+                {/if}
+            </div>
         {/each}
-        </tbody>
-    </Table>
+    </div>
     <PageNavigation bind:currentPage={page_number} totalPages={total_pages} refresh_function={fetchData}/>
 {:else}
     {$LL.TEAMS.TRANSFERS.NO_TRANSFERS()}
@@ -242,28 +216,55 @@
 </Dialog>
 
 <style>
-    div.flex {
+    .transfers {
         display: flex;
-        align-items: center;
-        flex-wrap: wrap;
+        flex-direction: column;
         gap: 5px;
     }
-    col.country {
-        width: 15%;
+    .top {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin-bottom: 10px;
     }
-    col.name {
-        width: 20%;
+    .row {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 10px;
+        align-items: center;
+        font-size: 0.9rem;
+        background-color: rgba(255, 255, 255, 0.15);
+        padding: 12px;
+        min-height: 75px;
     }
-    col.gamemode {
-        width: 15%;
+    .row:nth-child(odd) {
+        background-color: rgba(210, 210, 210, 0.15);
     }
-    col.between {
-        width: 20%;
+    .flag {
+        zoom: 85%;
     }
-    col.date {
-        width: 15%;
+    .date {
+        min-width: 200px;
     }
-    col.approve {
-        width: 15%;
+    .field {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 5px;
+    }
+    .left {
+        min-width: 200px;
+    }
+    .right {
+        min-width: 300px;
+    }
+    .badges {
+        min-width: 200px;
+    }
+    .approve {
+        min-width: 100px;
     }
   </style>

--- a/src/frontend/src/lib/types/user-settings.ts
+++ b/src/frontend/src/lib/types/user-settings.ts
@@ -5,4 +5,5 @@ export type UserSettings = {
   language: string;
   color_scheme: string;
   timezone: string;
+  hide_discord: boolean;
 };


### PR DESCRIPTION
- Made player search results taller
- Improve UI of recent transactions (on homepage and on its dedicated page)
- Added option to hide discord info from your profile (staff can still view, info also accessible from API for tournament organizers)
- Allow for searching for team tags in addition to names