### PR TITLE
Rate limiting, prevent double clicks, terms of service/privacy policy

### DIFF
--- a/src/backend/api/app.py
+++ b/src/backend/api/app.py
@@ -5,7 +5,7 @@ from api.data import on_startup, on_shutdown
 from api.endpoints import (authservice, roleservice, userservice, tournaments, 
                            tournament_registration, tournament_placements, player_registry, player_bans, 
                            team_registry, user_settings, notifications, moderation, mkcv1importer, posts)
-from api.utils.middleware import ProblemHandlingMiddleware, IPLoggingMiddleware
+from api.utils.middleware import ProblemHandlingMiddleware, IPLoggingMiddleware, RateLimitByIPMiddleware
 from api.utils.schema_gen import schema_route
 
 if appsettings.DEBUG:
@@ -31,9 +31,11 @@ routes = [
     schema_route
 ]
 
+
 middleware = [
     Middleware(ProblemHandlingMiddleware),
-    Middleware(IPLoggingMiddleware)
+    Middleware(IPLoggingMiddleware),
+    Middleware(RateLimitByIPMiddleware),
 ]
 
 app = Starlette(debug=True, routes=routes, on_startup=[on_startup], on_shutdown=[on_shutdown], middleware=middleware)

--- a/src/backend/api/endpoints/authservice.py
+++ b/src/backend/api/endpoints/authservice.py
@@ -226,6 +226,14 @@ async def link_discord(request: Request) -> Response:
 async def discord_callback(request: Request, discord_auth_data: DiscordAuthCallbackData) -> Response:
     redirect_params = ""
     user_data = request.state.user
+    # If they have not completed registration yet, redirect to registration page, otherwise edit profile page
+    if not request.state.user.player_id:
+        redirect_path = "/user/player-signup"
+    else:
+        redirect_path = "/registry/players/edit-profile"
+    if discord_auth_data.error:
+        return RedirectResponse(f"{redirect_path}{redirect_params}", 302)
+    assert discord_auth_data.code is not None
     try:
         if appsettings.ENABLE_DISCORD:
             command = LinkUserDiscordCommand(
@@ -245,12 +253,6 @@ async def discord_callback(request: Request, discord_auth_data: DiscordAuthCallb
             print(f"Problem raised during Discord auth callback: {e}")
         traceback.print_exc()
         redirect_params = "?auth_failed=1"
-
-    # If they have not completed registration yet, redirect to registration page, otherwise edit profile page
-    if not request.state.user.player_id:
-        redirect_path = "/user/player-signup"
-    else:
-        redirect_path = "/registry/players/edit-profile"
 
     async def sync_avatar():
         if appsettings.ENABLE_DISCORD:

--- a/src/backend/api/utils/middleware.py
+++ b/src/backend/api/utils/middleware.py
@@ -50,7 +50,6 @@ class RateLimitByIPMiddleware:
         ip_address = scope.get('CF-Connecting-IP', None)
         if not ip_address:
             ip_address = scope['client'][0]
-        print(ip_address)
         return ip_address, 'default'
     
     def on_blocked(self, retry_after: int):

--- a/src/backend/api/utils/middleware.py
+++ b/src/backend/api/utils/middleware.py
@@ -73,6 +73,9 @@ class RateLimitByIPMiddleware:
                 r"/api/user/refresh_discord": [Rule(minute=3, hour=10)],
                 r"/api/user/discord_callback": [Rule(minute=3, hour=10)],
                 r"/api/user/sync_discord_avatar": [Rule(minute=3, hour=10)],
+                r"/api/registry/teams/edit": [Rule(minute=3, hour=10)],
+                r"/api/tournaments/.*/create": [Rule(minute=3, hour=10)],
+                r"/api/tournaments/.*/edit": [Rule(minute=3, hour=10)],
             },
             on_blocked=self.on_blocked
         )

--- a/src/backend/common/auth/roles.py
+++ b/src/backend/common/auth/roles.py
@@ -4,6 +4,7 @@ SUPER_ADMINISTRATOR = "Super Administrator"
 ADMINISTRATOR = "Administrator"
 SITE_MODERATOR = "Site Moderator"
 SUPPORT_STAFF = "Support Staff"
+LOUNGE_STAFF = "Lounge Staff"
 SITE_SUPPORTER = "Site Supporter"
 EVENT_ADMIN = "Event Admin"
 EVENT_MOD = "Event Mod"
@@ -21,6 +22,7 @@ default_roles = [
     (6, SITE_SUPPORTER, 6),
     (7, BANNED, 99),
     (8, TEAM_LEADER_BANNED, 99),
+    (9, LOUNGE_STAFF, 5),
 ]
 
 id_by_default_role = { name: roleid for roleid, name, pos in default_roles} # type: ignore
@@ -178,6 +180,9 @@ default_permissions_by_default_role: dict[str, list[str]] = {
         team_permissions.REGISTER_TOURNAMENT,
         team_permissions.MANAGE_TOURNAMENT_ROSTERS,
     ],
+    LOUNGE_STAFF: [
+        permissions.VIEW_ALT_FLAGS,
+    ],
     SITE_SUPPORTER: [],
     BANNED: [],
     TEAM_LEADER_BANNED: [],
@@ -190,6 +195,7 @@ default_denied_permissions_by_default_role: dict[str, list[str]] = {
     EVENT_ADMIN: [],
     EVENT_MOD: [],
     SUPPORT_STAFF: [],
+    LOUNGE_STAFF: [],
     SITE_SUPPORTER: [],
     BANNED: [
         tournament_permissions.REGISTER_TOURNAMENT,

--- a/src/backend/common/data/commands/players/players.py
+++ b/src/backend/common/data/commands/players/players.py
@@ -65,7 +65,7 @@ class CreatePlayerCommand(Command[Player]):
                 async with db.execute("SELECT id FROM friend_codes WHERE fc = ? AND type = ? AND is_active = ?", (friend_code.fc, friend_code.type, True)) as cursor:
                     row = await cursor.fetchone()
                     if row:
-                        raise Problem("Another player is currently using this friend code for this game", status=400)
+                        raise Problem(f"Another player is currently using this {friend_code.type} friend code", status=400)
                     
             friend_code_tuples = [(player_id, friend_code.type, friend_code.fc, False, friend_code.is_primary, True, friend_code.description, now)
                                   for friend_code in self.friend_codes]

--- a/src/backend/common/data/models/discord_integration.py
+++ b/src/backend/common/data/models/discord_integration.py
@@ -2,8 +2,9 @@ from dataclasses import dataclass
 
 @dataclass
 class DiscordAuthCallbackData:
-    code: str
+    code: str | None = None
     state: str | None = None
+    error: str | None = None
 
 @dataclass
 class DiscordAccessTokenResponse:

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -3,6 +3,7 @@ aiohttp==3.10.5
 aiosmtplib==4.0.0
 aiosqlite==0.19.0
 argon2-cffi==23.1.0
+asgi-ratelimit==0.10.0
 bcrypt==4.1.2
 debugpy==1.8.0
 msgspec==0.18.6

--- a/src/frontend/src/i18n/de/index.ts
+++ b/src/frontend/src/i18n/de/index.ts
@@ -85,6 +85,7 @@ const de: Translation = {
     NEW: 'New',
     SORT_BY_ALPHABETICAL: 'Alphabetical',
     SORT_BY_NEWEST: 'Newest',
+    WORKING: 'Working...',
   },
   DISCORD: {
     DISCORD: 'Discord',

--- a/src/frontend/src/i18n/de/index.ts
+++ b/src/frontend/src/i18n/de/index.ts
@@ -237,6 +237,8 @@ const de: Translation = {
     NEW_EMAIL: 'New Email',
     CHANGE_EMAIL_SUCCESS: 'Successfully changed your email. Please check your inbox for a confirmation email.',
     CHANGE_EMAIL_FAILED: 'Failed to change email',
+    AGREE_TO_TERMS: 'I agree to the MKCentral Terms of Service.',
+    AGREE_TO_PRIVACY_POLICY: 'I agree to the MKCentral Privacy Policy.',
   },
   LOUNGE: {
     LOUNGE: 'Lounge',

--- a/src/frontend/src/i18n/en-us/index.ts
+++ b/src/frontend/src/i18n/en-us/index.ts
@@ -82,6 +82,7 @@ const en_us: BaseTranslation = {
     NEW: 'New',
     SORT_BY_ALPHABETICAL: 'Alphabetical',
     SORT_BY_NEWEST: 'Newest',
+    WORKING: 'Working...',
   },
   DISCORD: {
     DISCORD: 'Discord',

--- a/src/frontend/src/i18n/en-us/index.ts
+++ b/src/frontend/src/i18n/en-us/index.ts
@@ -234,6 +234,8 @@ const en_us: BaseTranslation = {
     NEW_EMAIL: 'New Email',
     CHANGE_EMAIL_SUCCESS: 'Successfully changed your email. Please check your inbox for a confirmation email.',
     CHANGE_EMAIL_FAILED: 'Failed to change email',
+    AGREE_TO_TERMS: 'I agree to the MKCentral Terms of Service.',
+    AGREE_TO_PRIVACY_POLICY: 'I agree to the MKCentral Privacy Policy.',
   },
   LOUNGE: {
     LOUNGE: 'Lounge',

--- a/src/frontend/src/i18n/es/index.ts
+++ b/src/frontend/src/i18n/es/index.ts
@@ -237,6 +237,8 @@ const es: Translation = {
     NEW_EMAIL: 'New Email',
     CHANGE_EMAIL_SUCCESS: 'Successfully changed your email. Please check your inbox for a confirmation email.',
     CHANGE_EMAIL_FAILED: 'Failed to change email',
+    AGREE_TO_TERMS: 'I agree to the MKCentral Terms of Service.',
+    AGREE_TO_PRIVACY_POLICY: 'I agree to the MKCentral Privacy Policy.',
   },
   LOUNGE: {
     LOUNGE: 'Lounge',

--- a/src/frontend/src/i18n/es/index.ts
+++ b/src/frontend/src/i18n/es/index.ts
@@ -85,6 +85,7 @@ const es: Translation = {
     NEW: 'New',
     SORT_BY_ALPHABETICAL: 'Alphabetical',
     SORT_BY_NEWEST: 'Newest',
+    WORKING: 'Working...',
   },
   DISCORD: {
     DISCORD: 'Discord',

--- a/src/frontend/src/i18n/fr/index.ts
+++ b/src/frontend/src/i18n/fr/index.ts
@@ -237,6 +237,8 @@ const fr: Translation = {
     NEW_EMAIL: 'New Email',
     CHANGE_EMAIL_SUCCESS: 'Successfully changed your email. Please check your inbox for a confirmation email.',
     CHANGE_EMAIL_FAILED: 'Failed to change email',
+    AGREE_TO_TERMS: 'I agree to the MKCentral Terms of Service.',
+    AGREE_TO_PRIVACY_POLICY: 'I agree to the MKCentral Privacy Policy.',
   },
   LOUNGE: {
     LOUNGE: 'Lounge',

--- a/src/frontend/src/i18n/fr/index.ts
+++ b/src/frontend/src/i18n/fr/index.ts
@@ -85,6 +85,7 @@ const fr: Translation = {
     NEW: 'New',
     SORT_BY_ALPHABETICAL: 'Alphabetical',
     SORT_BY_NEWEST: 'Newest',
+    WORKING: 'Working...',
   },
   DISCORD: {
     DISCORD: 'Discord',

--- a/src/frontend/src/i18n/i18n-types.ts
+++ b/src/frontend/src/i18n/i18n-types.ts
@@ -853,6 +853,14 @@ type RootTranslation = {
 		 * F​a​i​l​e​d​ ​t​o​ ​c​h​a​n​g​e​ ​e​m​a​i​l
 		 */
 		CHANGE_EMAIL_FAILED: string
+		/**
+		 * I​ ​a​g​r​e​e​ ​t​o​ ​t​h​e​ ​M​K​C​e​n​t​r​a​l​ ​T​e​r​m​s​ ​o​f​ ​S​e​r​v​i​c​e​.
+		 */
+		AGREE_TO_TERMS: string
+		/**
+		 * I​ ​a​g​r​e​e​ ​t​o​ ​t​h​e​ ​M​K​C​e​n​t​r​a​l​ ​P​r​i​v​a​c​y​ ​P​o​l​i​c​y​.
+		 */
+		AGREE_TO_PRIVACY_POLICY: string
 	}
 	LOUNGE: {
 		/**
@@ -5702,6 +5710,14 @@ export type TranslationFunctions = {
 		 * Failed to change email
 		 */
 		CHANGE_EMAIL_FAILED: () => LocalizedString
+		/**
+		 * I agree to the MKCentral Terms of Service.
+		 */
+		AGREE_TO_TERMS: () => LocalizedString
+		/**
+		 * I agree to the MKCentral Privacy Policy.
+		 */
+		AGREE_TO_PRIVACY_POLICY: () => LocalizedString
 	}
 	LOUNGE: {
 		/**

--- a/src/frontend/src/i18n/i18n-types.ts
+++ b/src/frontend/src/i18n/i18n-types.ts
@@ -326,6 +326,10 @@ type RootTranslation = {
 		 * N​e​w​e​s​t
 		 */
 		SORT_BY_NEWEST: string
+		/**
+		 * W​o​r​k​i​n​g​.​.​.
+		 */
+		WORKING: string
 	}
 	DISCORD: {
 		/**
@@ -5176,6 +5180,10 @@ export type TranslationFunctions = {
 		 * Newest
 		 */
 		SORT_BY_NEWEST: () => LocalizedString
+		/**
+		 * Working...
+		 */
+		WORKING: () => LocalizedString
 	}
 	DISCORD: {
 		/**

--- a/src/frontend/src/i18n/ja/index.ts
+++ b/src/frontend/src/i18n/ja/index.ts
@@ -85,6 +85,7 @@ const ja: Translation = {
     NEW: 'New',
     SORT_BY_ALPHABETICAL: 'Alphabetical',
     SORT_BY_NEWEST: 'Newest',
+    WORKING: 'Working...',
   },
   DISCORD: {
     DISCORD: 'Discord',

--- a/src/frontend/src/i18n/ja/index.ts
+++ b/src/frontend/src/i18n/ja/index.ts
@@ -237,6 +237,8 @@ const ja: Translation = {
     NEW_EMAIL: 'New Email',
     CHANGE_EMAIL_SUCCESS: 'Successfully changed your email. Please check your inbox for a confirmation email.',
     CHANGE_EMAIL_FAILED: 'Failed to change email',
+    AGREE_TO_TERMS: 'I agree to the MKCentral Terms of Service.',
+    AGREE_TO_PRIVACY_POLICY: 'I agree to the MKCentral Privacy Policy.',
   },
   LOUNGE: {
     LOUNGE: 'ラウンジ',

--- a/src/frontend/src/lib/base.css
+++ b/src/frontend/src/lib/base.css
@@ -63,6 +63,9 @@ option {
 input::placeholder {
   color: lightgrey;
 }
+input[type='checkbox']:checked {
+  background-color: theme('colors.primary.500'/ 40%);
+}
 a:hover {
   color: theme('colors.primary.300');
 }

--- a/src/frontend/src/lib/components/common/buttons/Button.svelte
+++ b/src/frontend/src/lib/components/common/buttons/Button.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Button } from 'flowbite-svelte';
+  import { Button, Spinner } from 'flowbite-svelte';
+  import LL from '$i18n/i18n-svelte';
 
   export let href: string | undefined = undefined;
   export let circle = false;
@@ -19,8 +20,16 @@
     | 'alternative'
     | 'none'
     | undefined = undefined;
+  export let working = false;
 </script>
 
-<Button pill={circle} class="{extra_classes} {circle ? '!p-2' : ''} hover:text-white" on:click {size} {href} {type} {disabled} {color}>
-  <slot />
+<Button pill={circle} class="{extra_classes} {circle ? '!p-2' : ''} hover:text-white" on:click {size} {href} {type} disabled={working || disabled} {color}>
+  {#if working}
+    <div class="flex gap-2 items-center">
+      <Spinner size=4/>
+      {$LL.COMMON.WORKING()}
+    </div>
+  {:else}
+    <slot />
+  {/if}
 </Button>

--- a/src/frontend/src/lib/components/login/LoginRegister.svelte
+++ b/src/frontend/src/lib/components/login/LoginRegister.svelte
@@ -88,7 +88,7 @@
                     <input name="password" type="password" required bind:value={password}/>
                 </div>
                 <div class="login-row">
-                    <Button extra_classes="login-btn" type="submit" disabled={working}>{$LL.LOGIN.LOGIN()}</Button>
+                    <Button extra_classes="login-btn" type="submit" {working}>{$LL.LOGIN.LOGIN()}</Button>
                     <div>
                         <a href="/{$page.params.lang}/user/reset-password">
                             {$LL.LOGIN.FORGOT_PASSWORD()}
@@ -99,7 +99,7 @@
         </div>
     </TabItem>
     <TabItem title={$LL.LOGIN.REGISTER()}>
-        <RegisterForm bind:email={email} bind:password={password} on:submit={() => loginOrSignup(false)}/>
+        <RegisterForm bind:email={email} bind:password={password} {working} on:submit={() => loginOrSignup(false)}/>
     </TabItem>
 </Tabs>
 

--- a/src/frontend/src/lib/components/login/LoginRegister.svelte
+++ b/src/frontend/src/lib/components/login/LoginRegister.svelte
@@ -105,15 +105,17 @@
 
 <style>
     div.form {
-        width: 300px;
+        max-width: 350px;
     }
     div.option {
         display: flex;
+        flex-wrap: wrap;
         align-items: center;
         margin-bottom: 10px;
     }
     div.login-row {
         display: flex;
+        flex-wrap: wrap;
         gap: 20px;
         align-items: center;
     }

--- a/src/frontend/src/lib/components/login/RegisterForm.svelte
+++ b/src/frontend/src/lib/components/login/RegisterForm.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import LL from "$i18n/i18n-svelte";
     import Button from "$lib/components/common/buttons/Button.svelte";
+    import { page } from "$app/stores";
 
     export let email = "";
     export let password = "";
@@ -12,8 +13,10 @@
     const min_length = 8;
 
     let confirm_password = "";
+    let agree_terms = false;
+    let agree_policy = false;
 
-    $: button_disabled = password.length < 8 || password != confirm_password;
+    $: button_disabled = password.length < 8 || password != confirm_password || (!is_change && (!agree_terms || !agree_policy));
 </script>
 
 <div class="form">
@@ -54,6 +57,28 @@
             </span>
             <input name="confirm-password" type="password" minlength={min_length} maxlength=64 bind:value={confirm_password} required/>
         </div>
+        {#if !is_change}
+            <div class="option">
+                <span class="agree-terms">
+                    <input name="terms" type="checkbox" bind:checked={agree_terms}/>
+                </span>
+                <div class="terms-label">
+                    <a href="/{$page.params.lang}/user/terms" target="_blank">
+                        {$LL.LOGIN.AGREE_TO_TERMS()}
+                    </a>
+                </div>
+            </div>
+            <div class="option">
+                <span class="agree-terms">
+                    <input name="privacy" type="checkbox" bind:checked={agree_policy}/>
+                </span>
+                <div class="terms-label">
+                    <a href="/{$page.params.lang}/user/privacy-policy" target="_blank">
+                        {$LL.LOGIN.AGREE_TO_PRIVACY_POLICY()}
+                    </a>
+                </div>
+            </div>
+        {/if}
         <div class="errors">
             {#if password.length && password.length < min_length}
                 <div>
@@ -84,7 +109,7 @@
 
 <style>
     .form {
-        width: 300px;
+        max-width: 350px;
     }
     span.item-label {
         display: inline-block;
@@ -92,6 +117,7 @@
     }
     .option {
         display: flex;
+        flex-wrap: wrap;
         align-items: center;
         margin-bottom: 10px;
     }
@@ -99,5 +125,8 @@
         color: #FFCCCB;
         margin-left: 5px;
         margin-bottom: 10px;
+    }
+    span.agree-terms {
+        margin-right: 10px;
     }
 </style>

--- a/src/frontend/src/lib/components/login/RegisterForm.svelte
+++ b/src/frontend/src/lib/components/login/RegisterForm.svelte
@@ -7,6 +7,7 @@
     export let old_password = "";
     export let is_change = false;
     export let is_reset = false;
+    export let working = false;
 
     const min_length = 8;
 
@@ -66,7 +67,7 @@
             {/if}
         </div>
         <div>
-            <Button type="submit" disabled={button_disabled}>
+            <Button type="submit" disabled={button_disabled} {working}>
                 {#if is_change}
                     {$LL.LOGIN.CHANGE_PASSWORD()}
                 {:else if is_reset}

--- a/src/frontend/src/lib/components/moderator/AltFlags.svelte
+++ b/src/frontend/src/lib/components/moderator/AltFlags.svelte
@@ -14,50 +14,53 @@
     };
 </script>
 
-<Table>
-    <col class="players">
-    <col class="type">
-    <col class="score">
-    <col class="data mobile-hide">
-    <col class="date mobile-hide">
-    <thead>
-        <tr>
-            <th>{$LL.MODERATOR.ALT_DETECTION.TABLE.PLAYERS()}</th>
-            <th>{$LL.MODERATOR.ALT_DETECTION.TABLE.TYPE()}</th>
-            <th>{$LL.MODERATOR.ALT_DETECTION.TABLE.SCORE()}</th>
-            <th class="mobile-hide">{$LL.MODERATOR.ALT_DETECTION.TABLE.DATA()}</th>
-            <th class="mobile-hide">{$LL.MODERATOR.ALT_DETECTION.TABLE.DETECTED_AT()}</th>
-        </tr>
-    </thead>
-    <tbody>
-        {#each flags as flag}
+{#if flags.length}
+    <Table>
+        <col class="players">
+        <col class="type">
+        <col class="score">
+        <col class="data mobile-hide">
+        <col class="date mobile-hide">
+        <thead>
             <tr>
-                <td>
-                    {#each flag.players as player}
-                        <a href="/{$page.params.lang}/registry/players/profile?id={player.id}">
-                            <div class="player-name">
-                                <Flag country_code={player.country_code}/>
-                                {player.name}
-                            </div>
-                        </a>
-                    {/each}
-                </td>
-                <td>
-                    {flag.type}
-                </td>
-                <td>
-                    {flag.score}
-                </td>
-                <td class="mobile-hide">
-                    {flag.data}
-                </td>
-                <td class="mobile-hide">
-                    {new Date(flag.date * 1000).toLocaleString($locale, options)}
-                </td>
+                <th>{$LL.MODERATOR.ALT_DETECTION.TABLE.PLAYERS()}</th>
+                <th>{$LL.MODERATOR.ALT_DETECTION.TABLE.TYPE()}</th>
+                <th>{$LL.MODERATOR.ALT_DETECTION.TABLE.SCORE()}</th>
+                <th class="mobile-hide">{$LL.MODERATOR.ALT_DETECTION.TABLE.DATA()}</th>
+                <th class="mobile-hide">{$LL.MODERATOR.ALT_DETECTION.TABLE.DETECTED_AT()}</th>
             </tr>
-        {/each}
-    </tbody>
-</Table>
+        </thead>
+        <tbody>
+            {#each flags as flag}
+                <tr>
+                    <td>
+                        {#each flag.players as player}
+                            <a href="/{$page.params.lang}/registry/players/profile?id={player.id}">
+                                <div class="player-name">
+                                    <Flag country_code={player.country_code}/>
+                                    {player.name}
+                                </div>
+                            </a>
+                        {/each}
+                    </td>
+                    <td>
+                        {flag.type}
+                    </td>
+                    <td>
+                        {flag.score}
+                    </td>
+                    <td class="mobile-hide">
+                        {flag.data}
+                    </td>
+                    <td class="mobile-hide">
+                        {new Date(flag.date * 1000).toLocaleString($locale, options)}
+                    </td>
+                </tr>
+            {/each}
+        </tbody>
+    </Table>
+{/if}
+
 
 <style>
     col.players {

--- a/src/frontend/src/lib/components/posts/CreateEditPost.svelte
+++ b/src/frontend/src/lib/components/posts/CreateEditPost.svelte
@@ -15,6 +15,7 @@
     let title = "";
     let is_public = true;
     let content = "";
+    let working = false;
 
     onMount(async() => {
         if(!id) return;
@@ -30,6 +31,7 @@
     });
 
     async function createEditPost(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+        working = true;
         const formData = new FormData(event.currentTarget);
         const payload = {
             title: formData.get("title"),
@@ -44,6 +46,7 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
+        working = false;
         const result = await response.json();
         if (response.status < 300) {
             let new_id = result["id"];
@@ -82,7 +85,7 @@
             <label for="content">{$LL.POSTS.CONTENT()}</label>
             <MarkdownTextArea name="content" bind:value={content}/>
         </div>
-        <Button type="submit">{$LL.COMMON.SUBMIT()}</Button>
+        <Button {working} type="submit">{$LL.COMMON.SUBMIT()}</Button>
     </form>
 </Section>
 

--- a/src/frontend/src/lib/components/registry/invites/TeamInvites.svelte
+++ b/src/frontend/src/lib/components/registry/invites/TeamInvites.svelte
@@ -27,6 +27,7 @@
     let decline_dialog: Dialog;
     let curr_invite: TeamInvite;
     let leave_roster_id: number | null = null;
+    let working = false;
 
     const options: Intl.DateTimeFormatOptions = {
         dateStyle: 'short',
@@ -57,8 +58,10 @@
     $: leaveable_rosters = curr_invite ? getLeaveableRosters(curr_invite) : [];
 
     async function acceptInvite(invite: TeamInvite) {
+        working = true;
         if(leaveable_rosters.length && !leave_roster_id) {
             alert($LL.INVITES.SELECT_LEAVE_ROSTER_ERROR());
+            working = false;
             return;
         }
         accept_dialog.close();
@@ -71,6 +74,7 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
+        working = false;
         const result = await res.json();
         if (res.status < 300) {
             alert($LL.INVITES.ACCEPT_TEAM_INVITE_SUCCESS({roster_name: invite.roster_name}));
@@ -80,6 +84,7 @@
         }
     }
     async function declineInvite(invite: TeamInvite) {
+        working = true;
         decline_dialog.close();
         const payload = {
             invite_id: invite.invite_id,
@@ -89,6 +94,7 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
+        working = false;
         const result = await res.json();
         if (res.status < 300) {
             window.location.reload();
@@ -157,16 +163,16 @@
       </select>
     {/if}
     <div class="accept">
-      <Button on:click={() => acceptInvite(curr_invite)}>{$LL.INVITES.ACCEPT()}</Button>
-      <Button on:click={accept_dialog.close}>Cancel</Button>
+      <Button {working} on:click={() => acceptInvite(curr_invite)}>{$LL.INVITES.ACCEPT()}</Button>
+      <Button on:click={accept_dialog.close}>{$LL.COMMON.CANCEL()}</Button>
     </div>
   </Dialog>
   
-  <Dialog bind:this={decline_dialog} header="Decline Team Invite">
+  <Dialog bind:this={decline_dialog} header={$LL.INVITES.DECLINE()}>
     {$LL.INVITES.DECLINE_TEAM_INVITE_CONFIRM({roster_name: curr_invite?.roster_name})}
     <br /><br />
     <div class="accept">
-      <Button on:click={() => declineInvite(curr_invite)}>{$LL.INVITES.DECLINE()}</Button>
+      <Button {working} on:click={() => declineInvite(curr_invite)}>{$LL.INVITES.DECLINE()}</Button>
       <Button on:click={decline_dialog.close}>{$LL.COMMON.CANCEL()}</Button>
     </div>
   </Dialog>

--- a/src/frontend/src/lib/components/registry/players/ClaimPlayer.svelte
+++ b/src/frontend/src/lib/components/registry/players/ClaimPlayer.svelte
@@ -5,8 +5,10 @@
     import LL from "$i18n/i18n-svelte";
 
     export let player: PlayerInfo;
+    let working = false;
 
     async function claimPlayer() {
+        working = true;
         const payload = {
             player_id: player.id
         };
@@ -16,6 +18,7 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
+        working = false;
         const result = await response.json();
         if (response.status < 300) {
             alert($LL.PLAYERS.SHADOW_PLAYERS.CLAIM_PLAYER_SUCCESS());
@@ -32,7 +35,7 @@
         {$LL.PLAYERS.SHADOW_PLAYERS.UNCLAIMED_PLAYER_DESCRIPTION()}
     </div>
     <div class="claim-button">
-        <Button on:click={claimPlayer}>{$LL.PLAYERS.SHADOW_PLAYERS.CLAIM_PLAYER()}</Button>
+        <Button {working} on:click={claimPlayer}>{$LL.PLAYERS.SHADOW_PLAYERS.CLAIM_PLAYER()}</Button>
     </div>
     
 </Section>

--- a/src/frontend/src/lib/components/registry/players/CreateShadowPlayerDialog.svelte
+++ b/src/frontend/src/lib/components/registry/players/CreateShadowPlayerDialog.svelte
@@ -5,12 +5,14 @@
     import LL from "$i18n/i18n-svelte";
 
     let player_dialog: Dialog;
+    let working = false;
 
     export function open() {
         player_dialog.open();
     }
 
     async function createPlayer(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+        working = true;
         const data = new FormData(event.currentTarget);
         const payload = {
             name: data.get('shadow_name')!.toString(),
@@ -23,6 +25,7 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
+        working = false;
         const result = await response.json();
         if(response.status < 300) {
             alert($LL.PLAYERS.SHADOW_PLAYERS.CREATE_SHADOW_PLAYER_SUCCESS());
@@ -45,7 +48,7 @@
             <CountrySelect is_required/>
         </div>
         <div class="option">
-            <Button type="submit">{$LL.PLAYERS.SHADOW_PLAYERS.CREATE_SHADOW_PLAYER()}</Button>
+            <Button {working} type="submit">{$LL.PLAYERS.SHADOW_PLAYERS.CREATE_SHADOW_PLAYER()}</Button>
         </div>
     </form>
 </Dialog>

--- a/src/frontend/src/lib/components/registry/players/EditFriendCodes.svelte
+++ b/src/frontend/src/lib/components/registry/players/EditFriendCodes.svelte
@@ -10,6 +10,7 @@
 
     export let player: PlayerInfo;
     export let is_privileged = false;
+    let working = false;
 
     let add_fc_dialog: Dialog;
     let edit_fc_dialog: Dialog;
@@ -24,8 +25,8 @@
     }
 
     async function edit_fc_privileged(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+        working = true;
         const data = new FormData(event.currentTarget);
-        console.log(data.get('is_primary'));
         const payload = {
             player_id: player.id,
             id: selected_fc?.id,
@@ -41,6 +42,7 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
+        working = false;
         const result = await response.json();
 
         if (response.status < 300) {
@@ -51,19 +53,20 @@
     }
 
     async function edit_fc(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+        working = true;
         const data = new FormData(event.currentTarget);
         const payload = {
             id: selected_fc?.id,
             is_primary: data.get('is_primary') ? true : false,
             description: data.get('description')?.toString(),
         };
-        console.log(payload);
         const endpoint = '/api/registry/editFriendCode';
         const response = await fetch(endpoint, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
+        working = false;
         const result = await response.json();
 
         if (response.status < 300) {
@@ -132,7 +135,7 @@
                         </div>
                     </div>
                 {/if}
-                <Button type="submit">{$LL.COMMON.EDIT()}</Button>
+                <Button {working} type="submit">{$LL.COMMON.EDIT()}</Button>
             </div>
         </form>
     {/if}

--- a/src/frontend/src/lib/components/registry/players/EditPlayerDetails.svelte
+++ b/src/frontend/src/lib/components/registry/players/EditPlayerDetails.svelte
@@ -8,22 +8,24 @@
     export let player: PlayerInfo;
     export let is_privileged = false;
 
+    let working = false;
+
     let pending_change = player.name_changes.find((n) => n.approval_status === 'pending');
 
     async function requestNameChange(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+        working = true;
         const data = new FormData(event.currentTarget);
         const payload = {
             name: data.get('name')?.toString(),
         };
-        console.log(payload);
         const endpoint = '/api/registry/players/requestName';
         const response = await fetch(endpoint, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
+        working = false;
         const result = await response.json();
-
         if (response.status < 300) {
             window.location.reload();
         } else {
@@ -32,6 +34,7 @@
     }
 
     async function forceEditPlayer(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+        working = true;
         const data = new FormData(event.currentTarget);
         const payload = {
             player_id: player.id,
@@ -40,13 +43,13 @@
             is_hidden: data.get('is_hidden') === 'true',
             is_shadow: player.is_shadow
         };
-        console.log(payload);
         const endpoint = '/api/registry/players/edit';
         const response = await fetch(endpoint, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
+        working = false;
         const result = await response.json();
 
         if (response.status < 300) {
@@ -64,7 +67,7 @@
                 <label for="name">{$LL.PLAYERS.PROFILE.DISPLAY_NAME()}</label>
                 <Input name="name" value={player.name} required maxlength={20} no_white_space/>
             </div>
-            <Button type="submit">{$LL.PLAYERS.PROFILE.REQUEST_NAME_CHANGE()}</Button>
+            <Button {working} type="submit">{$LL.PLAYERS.PROFILE.REQUEST_NAME_CHANGE()}</Button>
         </form>
     {:else}
         <div class="bold">
@@ -91,7 +94,7 @@
                 <option value={true}>{$LL.COMMON.HIDE()}</option>
             </select>
         </div>
-        <Button type="submit">{$LL.COMMON.EDIT()}</Button>
+        <Button {working} type="submit">{$LL.COMMON.EDIT()}</Button>
     </form>
 {/if}
 

--- a/src/frontend/src/lib/components/registry/players/FriendCodeForm.svelte
+++ b/src/frontend/src/lib/components/registry/players/FriendCodeForm.svelte
@@ -7,6 +7,7 @@
     export let player: PlayerInfo | null;
     export let is_privileged = false;
     let selected_type: string | null = null;
+    let working = false;
 
     const fc_limits: { [key: string]: number } = { switch: 1, mkt: 1, mkw: 4, '3ds': 1, nnid: 1 };
 
@@ -21,6 +22,7 @@
     }
 
     async function addFC(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+        working = true;
         const data = new FormData(event.currentTarget);
         const payload = {
             fc: data.get('fc')?.toString().replaceAll(" ", "-"),
@@ -35,6 +37,7 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
+        working = false;
         const result = await response.json();
 
         if (response.status < 300) {
@@ -45,6 +48,7 @@
     }
 
     async function forceAddFC(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+        working = true;
         const data = new FormData(event.currentTarget);
         const payload = {
             player_id: player?.id,
@@ -60,6 +64,7 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
+        working = false;
         const result = await response.json();
 
         if (response.status < 300) {
@@ -102,7 +107,7 @@
                     <input name="description" placeholder={$LL.FRIEND_CODES.DESCRIPTION()} maxlength=200/>
                 </div>
             </div>
-            <Button type="submit">{$LL.COMMON.SUBMIT()}</Button>
+            <Button {working} type="submit">{$LL.COMMON.SUBMIT()}</Button>
         </div>
     </form>
 {/if}

--- a/src/frontend/src/lib/components/registry/teams/EditTeam.svelte
+++ b/src/frontend/src/lib/components/registry/teams/EditTeam.svelte
@@ -18,6 +18,7 @@
   
     let id = 0;
     let team: Team;
+    let working = false;
   
     $: team_name = team ? team.name : $LL.NAVBAR.REGISTRY();
 
@@ -41,6 +42,7 @@
     });
   
     async function editTeam(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+      working = true;
       const data = new FormData(event.currentTarget);
       function getOptionalValue(name: string) {
         return data.get(name) ? data.get(name)?.toString() : '';
@@ -53,13 +55,13 @@
         language: data.get('language')?.toString(),
         description: getOptionalValue('description'),
       };
-      console.log(payload);
       const endpoint = '/api/registry/teams/edit';
       const response = await fetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       });
+      working = false;
       const result = await response.json();
       if (response.status < 300) {
         window.location.reload();
@@ -70,6 +72,7 @@
     }
 
     async function forceEditTeam(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+      working = true;
       const data = new FormData(event.currentTarget);
       function getOptionalValue(name: string) {
         return data.get(name) ? data.get(name)?.toString() : '';
@@ -86,13 +89,13 @@
         approval_status: data.get('approval_status'),
         is_historical: getOptionalValue('is_historical') === 'true',
       };
-      console.log(payload);
       const endpoint = '/api/registry/teams/forceEdit';
       const response = await fetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       });
+      working = false;
       const result = await response.json();
       if (response.status < 300) {
         window.location.reload();
@@ -140,7 +143,7 @@
               <br />
           </Section>
           <Section header={$LL.COMMON.SUBMIT()}>
-              <Button type="submit">{$LL.COMMON.SUBMIT()}</Button>
+              <Button {working} type="submit">{$LL.COMMON.SUBMIT()}</Button>
           </Section>
         </form>
       {/if}
@@ -183,8 +186,8 @@
               <option value="true">{$LL.TEAMS.PROFILE.HISTORICAL()}</option>
             </select>
           </Section>
-          <Section header="Submit">
-            <Button type="submit">{$LL.TEAMS.PROFILE.EDIT_TEAM()}</Button>
+          <Section header={$LL.COMMON.SUBMIT()}>
+            <Button {working} type="submit">{$LL.TEAMS.PROFILE.EDIT_TEAM()}</Button>
           </Section>
         </form>
       {/if}

--- a/src/frontend/src/lib/components/registry/teams/ForceTransferPlayer.svelte
+++ b/src/frontend/src/lib/components/registry/teams/ForceTransferPlayer.svelte
@@ -11,6 +11,7 @@
     let from_roster: PlayerRoster | null = null;
     let to_roster: TeamRoster | null = null;
     let is_bagger: boolean = false;
+    let working = false;
 
     $: is_bagger = from_roster ? from_roster.is_bagger_clause : is_bagger;
 
@@ -44,6 +45,7 @@
         if(!player || !to_roster) {
             return;
         }
+        working = true;
         const payload = {
             player_id: player.id,
             roster_id: to_roster.id,
@@ -57,6 +59,7 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
+        working = false;
         console.log(payload);
         const result = await res.json();
         if (res.status < 300) {
@@ -108,7 +111,7 @@
             </div>
         {/if}
         {#if to_roster}
-            <Button on:click={transferPlayer}>{$LL.MODERATOR.TRANSFER_PLAYER()}</Button>
+            <Button on:click={transferPlayer} {working}>{$LL.MODERATOR.TRANSFER_PLAYER()}</Button>
         {/if}
     </div>
 {/if}

--- a/src/frontend/src/lib/components/registry/teams/ManageRosters.svelte
+++ b/src/frontend/src/lib/components/registry/teams/ManageRosters.svelte
@@ -24,6 +24,8 @@
     user.subscribe((value) => {
       user_info = value;
     });
+
+    let working = false;
   
     onMount(async () => {
       let param_id = $page.url.searchParams.get('id');
@@ -37,6 +39,7 @@
     });
   
     async function createRoster(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+      working = true;
       const data = new FormData(event.currentTarget);
       function getOptionalValue(name: string) {
         return data.get(name) ? data.get(name)?.toString() : '';
@@ -49,13 +52,13 @@
         tag: data.get('tag')?.toString(),
         is_recruiting: getOptionalValue('recruiting') === 'true' ? true : false,
       };
-      console.log(payload);
       const endpoint = '/api/registry/teams/requestCreateRoster';
       const response = await fetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       });
+      working = false;
       const result = await response.json();
       if (response.status < 300) {
         window.location.reload();
@@ -116,7 +119,7 @@
             </div>
           </div>
           <div>
-            <Button type="submit">{$LL.COMMON.SUBMIT()}</Button>
+            <Button type="submit" {working}>{$LL.COMMON.SUBMIT()}</Button>
           </div>
         </form>
       </Section>

--- a/src/frontend/src/lib/components/registry/teams/RosterNameTagRequest.svelte
+++ b/src/frontend/src/lib/components/registry/teams/RosterNameTagRequest.svelte
@@ -13,6 +13,7 @@
 
     let days_until_change = 0;
     let days_between_changes = 90;
+    let working = false;
 
     onMount(async() => {
         const res = await fetch(`/api/registry/teams/${roster.team_id}/rosterEditRequests/${roster.id}`);
@@ -32,6 +33,7 @@
     });
 
     async function editNameTag(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+        working = true;
         const data = new FormData(event.currentTarget);
         const payload = {
             roster_id: roster.id,
@@ -46,6 +48,7 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
+        working = false;
         const result = await response.json();
         if (response.status < 300) {
             window.location.reload();
@@ -85,7 +88,7 @@
             <label for="tag">{$LL.TEAMS.EDIT.ROSTER_TAG()}</label>
             <Input name="tag" type="text" value={roster.tag} required disabled={days_until_change > 0} maxlength={5} no_white_space/>
         </div>
-        <Button type="submit" disabled={days_until_change > 0}>{$LL.TEAMS.EDIT.REQUEST_NAME_TAG_CHANGE()}</Button>
+        <Button type="submit" disabled={days_until_change > 0} {working}>{$LL.TEAMS.EDIT.REQUEST_NAME_TAG_CHANGE()}</Button>
     {/if}
 </form>
 

--- a/src/frontend/src/lib/components/registry/teams/TeamNameTagRequest.svelte
+++ b/src/frontend/src/lib/components/registry/teams/TeamNameTagRequest.svelte
@@ -12,6 +12,7 @@
 
     let days_until_change = 0;
     let days_between_changes = 90;
+    let working = false;
 
     onMount(async() => {
         const res = await fetch(`/api/registry/teams/${team.id}/editRequests`);
@@ -31,6 +32,7 @@
     });
 
     async function editNameTag(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+        working = true;
       const data = new FormData(event.currentTarget);
       const payload = {
         team_id: team.id,
@@ -44,6 +46,7 @@
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       });
+      working = false;
       const result = await response.json();
       if (response.status < 300) {
         window.location.reload();
@@ -84,7 +87,7 @@
             <input name="tag" type="text" value={team.tag} required disabled={days_until_change > 0} maxlength=5/>
         </div>
         <div class="submit">
-            <Button type="submit" disabled={days_until_change > 0}>{$LL.TEAMS.EDIT.REQUEST_NAME_TAG_CHANGE()}</Button>
+            <Button type="submit" disabled={days_until_change > 0} {working}>{$LL.TEAMS.EDIT.REQUEST_NAME_TAG_CHANGE()}</Button>
         </div>
     {/if}
 </form>

--- a/src/frontend/src/lib/components/registry/teams/TeamRosterManage.svelte
+++ b/src/frontend/src/lib/components/registry/teams/TeamRosterManage.svelte
@@ -40,6 +40,8 @@
       user_info = value;
     });
 
+  let working = false;
+
   const options: Intl.DateTimeFormatOptions = {
     year: 'numeric',
     month: 'short',
@@ -59,6 +61,7 @@
   }
 
   async function invitePlayer(player_id: number) {
+    working = true;
     const payload = {
       team_id: roster.team_id,
       roster_id: roster.id,
@@ -75,17 +78,18 @@
     if (response.status < 300) {
       window.location.reload();
     } else {
+      working = false;
       alert(`${$LL.TEAMS.EDIT.PLAYER_INVITE_FAILED()}: ${result['title']}`);
     }
   }
 
   async function retractInvite(player_id: number) {
+    working = true;
     const payload = {
       team_id: roster.team_id,
       roster_id: roster.id,
       player_id: player_id,
     };
-    console.log(payload);
     let endpoint: string;
     if(is_mod) {
       endpoint = '/api/registry/teams/forceDeleteInvite';
@@ -98,11 +102,12 @@
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
-    });
+    });  
     const result = await response.json();
     if (response.status < 300) {
       window.location.reload();
     } else {
+      working = false;
       alert(`${$LL.TEAMS.EDIT.DELETE_INVITE_FAILED()}: ${result['title']}`);
     }
   }
@@ -113,13 +118,12 @@
   }
 
   async function kickPlayer(player: RosterPlayer) {
-    console.log(player);
+    working = true;
     const payload = {
       player_id: player.player_id,
       roster_id: roster.id,
       team_id: roster.team_id,
     };
-    console.log(payload);
     let endpoint: string;
     if(is_mod) {
       endpoint = '/api/registry/teams/forceKickPlayer';
@@ -137,11 +141,13 @@
     if (response.status < 300) {
       window.location.reload();
     } else {
+      working = false;
       alert(`${$LL.TEAMS.EDIT.PLAYER_KICK_FAILED()}: ${result['title']}`);
     }
   }
 
   async function editRoster(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+    working = true;
     edit_dialog.close();
     const data = new FormData(event.currentTarget);
     function getOptionalValue(name: string) {
@@ -158,16 +164,19 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
+    
     const result = await response.json();
     if (response.status < 300) {
       window.location.reload();
       alert($LL.TEAMS.EDIT.ROSTER_EDIT_SUCCESS());
     } else {
+      working = false;
       alert(`${$LL.TEAMS.EDIT.ROSTER_EDIT_FAILED()}: ${result['title']}`);
     }
   }
 
   async function forceEditRoster(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+    working = true;
     edit_dialog.close();
     const data = new FormData(event.currentTarget);
     function getOptionalValue(name: string) {
@@ -188,18 +197,22 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
+    
     const result = await response.json();
     if (response.status < 300) {
       window.location.reload();
       alert($LL.TEAMS.EDIT.ROSTER_EDIT_SUCCESS());
     } else {
+      working = false;
       alert(`${$LL.TEAMS.EDIT.ROSTER_EDIT_FAILED()}: ${result['title']}`);
     }
   }
 
   async function grantTeamRole(player: RosterPlayer, role_name: string) {
     let conf = window.confirm($LL.TEAMS.EDIT.TEAM_ROLE_ADD_CONFIRM({player_name: player.name, team_role: role_name}));
-    if(!conf) return;
+    if(!conf) {
+      return;
+    }
     const payload = {
       player_id: player.player_id,
       role_name: role_name
@@ -220,7 +233,9 @@
 
   async function removeTeamRole(player: RosterPlayer, role_name: string) {
     let conf = window.confirm($LL.TEAMS.EDIT.TEAM_ROLE_REMOVE_CONFIRM({player_name: player.name, team_role: role_name}));
-    if(!conf) return;
+    if(!conf) {
+      return;
+    }
     const payload = {
       player_id: player.player_id,
       role_name: role_name
@@ -352,7 +367,7 @@
                 <td class="mobile-hide">{player.friend_codes.filter((fc) => fc.type === game_fc_types[roster.game])[0].fc}</td>
                 <td class="mobile-hide">{new Date(player.invite_date * 1000).toLocaleString($locale, options)}</td>
                 <td>
-                  <Button on:click={() => retractInvite(player.player_id)}>{$LL.TEAMS.EDIT.RETRACT_INVITE()}</Button>
+                  <Button {working} on:click={() => retractInvite(player.player_id)}>{$LL.TEAMS.EDIT.RETRACT_INVITE()}</Button>
                 </td>
               </tr>
             {/each}
@@ -378,7 +393,7 @@
               </select>
             </div>
           {/if}
-          <Button on:click={() => invitePlayer(Number(invite_player?.id))}>{$LL.TEAMS.EDIT.INVITE_PLAYER()}</Button>
+          <Button {working} on:click={() => invitePlayer(Number(invite_player?.id))}>{$LL.TEAMS.EDIT.INVITE_PLAYER()}</Button>
         {/if}
       </div>
     {/if}
@@ -393,7 +408,7 @@
 <Dialog bind:this={kick_dialog} header={$LL.TEAMS.EDIT.KICK_PLAYER()}>
   {$LL.TEAMS.EDIT.KICK_CONFIRM({player_name: curr_player?.name})}
   <div>
-    <Button on:click={() => kickPlayer(curr_player)}>{$LL.TEAMS.EDIT.KICK()}</Button>
+    <Button {working} on:click={() => kickPlayer(curr_player)}>{$LL.TEAMS.EDIT.KICK()}</Button>
     <Button on:click={kick_dialog.close}>{$LL.COMMON.CANCEL()}</Button>
   </div>
 </Dialog>
@@ -408,7 +423,7 @@
       <option value="false">{$LL.TEAMS.PROFILE.RECRUITMENT_STATUS.NOT_RECRUITING()}</option>
     </select>
     <br />
-    <Button type="submit">{$LL.COMMON.SUBMIT()}</Button>
+    <Button {working} type="submit">{$LL.COMMON.SUBMIT()}</Button>
   </form>
 </Dialog>
 
@@ -438,7 +453,7 @@
       <option value="false">{$LL.TEAMS.PROFILE.HISTORICAL()}</option>
     </select>
     <br />
-    <Button type="submit">{$LL.TEAMS.EDIT.EDIT_ROSTER()}</Button>
+    <Button {working} type="submit">{$LL.TEAMS.EDIT.EDIT_ROSTER()}</Button>
   </form>
 </Dialog>
 

--- a/src/frontend/src/lib/components/tournaments/CreateEditTournamentForm.svelte
+++ b/src/frontend/src/lib/components/tournaments/CreateEditTournamentForm.svelte
@@ -61,6 +61,7 @@
 
   let is_edit = tournament_id ? true : false; // if we specified a tournament id, assume we're editing that tournament
   let data_retrieved = false; // wait to generate form before data is gotten from API, if any
+  let working = false;
 
   function updateData() {
     data = data;
@@ -80,6 +81,7 @@
   });
 
   async function createTournament(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+    working = true;
     const formData = new FormData(event.currentTarget);
     function getDate(name: string) {
       let date_form = formData.get(name);
@@ -95,6 +97,7 @@
     let registration_deadline: number | null = getDate('registration_deadline');
     if (date_start && date_end && date_start > date_end) {
       alert($LL.TOURNAMENTS.MANAGE.START_BEFORE_END_DATE());
+      working = false;
       return;
     }
     data.date_start = Number(date_start);
@@ -109,6 +112,7 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
+    working = false;
     const result = await response.json();
     if (response.status < 300) {
       let new_id = result["id"];
@@ -123,6 +127,7 @@
     if (!tournament_id) {
       return;
     }
+    working = true;
     const formData = new FormData(event.currentTarget);
     function getDate(name: string) {
       let date_form = formData.get(name);
@@ -138,6 +143,7 @@
     let registration_deadline: number | null = getDate('registration_deadline');
     if (date_start && date_end && date_start > date_end) {
       alert($LL.TOURNAMENTS.MANAGE.START_BEFORE_END_DATE());
+      working = false;
       return;
     }
     data.date_start = Number(date_start);
@@ -152,6 +158,7 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
+    working = false;
     const result = await response.json();
     if (response.status < 300) {
       goto(`/${$page.params.lang}/tournaments/details?id=${tournament_id}`);
@@ -167,7 +174,7 @@
     <Section header={is_edit ? $LL.TOURNAMENTS.MANAGE.EDIT_TOURNAMENT() : $LL.TOURNAMENTS.CREATE_TOURNAMENT()} />
     <TournamentDetailsForm {data} update_function={updateData} {is_edit} {series_restrict} />
     <Section header="Submit">
-      <Button type="submit">{is_edit ? $LL.TOURNAMENTS.MANAGE.EDIT_TOURNAMENT() : $LL.TOURNAMENTS.CREATE_TOURNAMENT()}</Button>
+      <Button type="submit" {working}>{is_edit ? $LL.TOURNAMENTS.MANAGE.EDIT_TOURNAMENT() : $LL.TOURNAMENTS.CREATE_TOURNAMENT()}</Button>
     </Section>
   </form>
 {/if}

--- a/src/frontend/src/lib/components/tournaments/TournamentDetailsForm.svelte
+++ b/src/frontend/src/lib/components/tournaments/TournamentDetailsForm.svelte
@@ -72,6 +72,9 @@
     if (data.game !== 'mkw' || !data.is_squad) {
       data.bagger_clause_enabled = false;
     }
+    if(!data.is_viewable) {
+      data.is_public = false;
+    }
     update_function();
   }
 </script>

--- a/src/frontend/src/lib/components/tournaments/registration/AddPlayerToSquad.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/AddPlayerToSquad.svelte
@@ -13,6 +13,7 @@
     export let tournament: Tournament;
     let player: PlayerInfo | null = null;
     let squad: TournamentSquad;
+    let working = false;
 
     let add_player_dialog: Dialog;
 
@@ -24,6 +25,7 @@
 
     async function addPlayer(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
         if(!squad || !player) return;
+        working = true;
         const formData = new FormData(event.currentTarget);
         let selected_fc_id = formData.get('selected_fc_id');
         let mii_name = formData.get('mii_name');
@@ -56,6 +58,7 @@
         if (response.status < 300) {
             window.location.reload();
         } else {
+            working = false;
             alert(`${$LL.TOURNAMENTS.REGISTRATIONS.ADD_PLAYER_FAILED()}: ${result['title']}`);
         }
     }
@@ -69,7 +72,7 @@
                 <SoloTournamentFields {tournament} friend_codes={player.friend_codes}/>
                 <TournamentStaffFields {tournament} squad_exists={true}/>
                 <div class="confirm">
-                    <Button type="submit">{$LL.TOURNAMENTS.REGISTRATIONS.ADD_PLAYER()}</Button>
+                    <Button {working} type="submit">{$LL.TOURNAMENTS.REGISTRATIONS.ADD_PLAYER()}</Button>
                     <Button type="button" on:click={add_player_dialog.close}>{$LL.COMMON.CANCEL()}</Button>
                 </div>
             </form>

--- a/src/frontend/src/lib/components/tournaments/registration/EditPlayerRegistration.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/EditPlayerRegistration.svelte
@@ -10,6 +10,7 @@
     export let tournament: Tournament;
     let player: TournamentPlayer;
     let is_privileged = false;
+    let working = false;
 
     let edit_reg_dialog: Dialog;
 
@@ -20,6 +21,7 @@
     }
 
     async function editRegistration(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+        working = true;
         const formData = new FormData(event.currentTarget);
         let selected_fc_id = formData.get('selected_fc_id');
         let mii_name = formData.get('mii_name');
@@ -43,12 +45,12 @@
             is_approved: is_approved !== null ? is_approved === "true" : null,
         };
         const endpoint = `/api/tournaments/${tournament.id}/editRegistration`;
-        console.log(payload);
         const response = await fetch(endpoint, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
+        working = false;
         const result = await response.json();
         if (response.status < 300) {
             window.location.reload();
@@ -58,6 +60,7 @@
     }
 
     async function editMyRegistration(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+        working = true;
         const formData = new FormData(event.currentTarget);
         let selected_fc_id = formData.get('selected_fc_id');
         let mii_name = formData.get('mii_name');
@@ -69,12 +72,12 @@
             squad_id: player.squad_id,
         };
         const endpoint = `/api/tournaments/${tournament.id}/editMyRegistration`;
-        console.log(payload);
         const response = await fetch(endpoint, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
+        working = false;
         const result = await response.json();
         if (response.status < 300) {
             window.location.reload();
@@ -98,7 +101,7 @@
                 <TournamentStaffFields {tournament} {player} squad_exists={true}/>
             {/if}
             <div class="confirm">
-                <Button type="submit">{$LL.TOURNAMENTS.REGISTRATIONS.EDIT_REGISTRATION()}</Button>
+                <Button {working} type="submit">{$LL.TOURNAMENTS.REGISTRATIONS.EDIT_REGISTRATION()}</Button>
                 <Button type="button" on:click={edit_reg_dialog.close}>{$LL.COMMON.CANCEL()}</Button>
             </div>
         </form>

--- a/src/frontend/src/lib/components/tournaments/registration/EditSquadDialog.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/EditSquadDialog.svelte
@@ -11,6 +11,7 @@
 
     let edit_squad_dialog: Dialog;
     let squad: TournamentSquad;
+    let working = false;
     
     export function open(selected_squad: TournamentSquad) {
         squad = selected_squad;
@@ -18,6 +19,7 @@
     }
 
     async function editSquad(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+        working = true;
         const formData = new FormData(event.currentTarget);
         let squad_color = formData.get('squad_color');
         let squad_name = formData.get('squad_name');
@@ -36,6 +38,7 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
+        working = false;
         const result = await response.json();
         if (response.status < 300) {
             window.location.reload();
@@ -45,6 +48,7 @@
     }
 
     async function editMySquad(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+        working = true;
         const formData = new FormData(event.currentTarget);
         let squad_color = formData.get('squad_color');
         let squad_name = formData.get('squad_name');
@@ -61,6 +65,7 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
+        working = false;
         const result = await response.json();
         if (response.status < 300) {
             window.location.reload();
@@ -86,7 +91,7 @@
                 </div>
             {/if}
             <div>
-                <Button type="submit">{$LL.TOURNAMENTS.REGISTRATIONS.EDIT_SQUAD()}</Button>
+                <Button {working} type="submit">{$LL.TOURNAMENTS.REGISTRATIONS.EDIT_SQUAD()}</Button>
                 <Button type="button" on:click={edit_squad_dialog.close}>{$LL.COMMON.CANCEL()}</Button>
             </div>
         </form>

--- a/src/frontend/src/lib/components/tournaments/registration/ForceRegisterSoloSquad.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/ForceRegisterSoloSquad.svelte
@@ -15,6 +15,7 @@
 
     export let tournament: Tournament;
     let player: PlayerInfo | null;
+    let working = false;
 
     let shadow_dialog: CreateShadowPlayerDialog;
 
@@ -25,6 +26,7 @@
 
     async function registerSolo(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
         if(!player) return;
+        working = true;
         const formData = new FormData(event.currentTarget);
         let selected_fc_id = formData.get('selected_fc_id');
         let mii_name = formData.get('mii_name');
@@ -40,12 +42,12 @@
             is_approved: is_approved === 'true'    
         };
         const endpoint = `/api/tournaments/${tournament.id}/forceRegister`;
-        console.log(payload);
         const response = await fetch(endpoint, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
+        working = false;
         const result = await response.json();
         if (response.status < 300) {
             window.location.reload();
@@ -56,6 +58,7 @@
     }
     async function registerSquad(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
         if(!player) return;
+        working = true;
         const formData = new FormData(event.currentTarget);
         let squad_color = formData.get('squad_color');
         let squad_name = formData.get('squad_name');
@@ -79,12 +82,12 @@
             is_approved: is_approved === 'true'
         };
         const endpoint = `/api/tournaments/${tournament.id}/forceCreateSquad`;
-        console.log(payload);
         const response = await fetch(endpoint, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
+        working = false;
         const result = await response.json();
         if (response.status < 300) {
             window.location.reload();
@@ -112,7 +115,7 @@
             <SquadTournamentFields {tournament}/>
             <SoloTournamentFields {tournament} friend_codes={player.friend_codes}/>
             <TournamentStaffFields {tournament}/>
-            <Button type="submit">{$LL.TOURNAMENTS.REGISTRATIONS.REGISTER()}</Button>
+            <Button {working} type="submit">{$LL.TOURNAMENTS.REGISTRATIONS.REGISTER()}</Button>
         </form>
     {/if}
 </div>

--- a/src/frontend/src/lib/components/tournaments/registration/ManageSquadRosters.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/ManageSquadRosters.svelte
@@ -41,7 +41,7 @@
         }
         let conf = window.confirm($LL.TOURNAMENTS.REGISTRATIONS.ADD_ROSTER_CONFIRM({roster_name: roster.name}));
         if(!conf) return;
-            const payload = {
+        const payload = {
             squad_id: squad.id,
             roster_id: roster.id
         }

--- a/src/frontend/src/lib/components/tournaments/registration/MyRegistration.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/MyRegistration.svelte
@@ -11,6 +11,8 @@
   export let registration: MyTournamentRegistration;
   export let tournament: Tournament;
 
+  let working = false;
+
   function getInvitedSquads() {
     let invite_registrations = registration.registrations.filter((r) => r.player.is_invite);
     // this line is mostly for the linter to know that none of the squad values will be null
@@ -18,6 +20,7 @@
   }
 
   async function toggleCheckin(reg: RegistrationDetails) {
+    working = true;
     const payload = {
       tournament_id: tournament.id,
       squad_id: reg.player.squad_id,
@@ -29,6 +32,7 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
+    working = false;
     const result = await response.json();
     if (response.status < 300) {
       window.location.reload();
@@ -52,7 +56,7 @@
       <div class="section">
         {#if tournament.checkins_open}
           {#if !reg.player.is_checked_in}
-            <Button on:click={() => toggleCheckin(reg)}>{$LL.TOURNAMENTS.REGISTRATIONS.CHECK_IN_BUTTON()}</Button>
+            <Button {working} on:click={() => toggleCheckin(reg)}>{$LL.TOURNAMENTS.REGISTRATIONS.CHECK_IN_BUTTON()}</Button>
             <div>
               {$LL.TOURNAMENTS.REGISTRATIONS.CHECK_IN_REMINDER_WINDOW_OPEN()}
             </div>
@@ -69,7 +73,7 @@
               {/if}
             </div>
             <div>
-              <Button size="xs" on:click={() => toggleCheckin(reg)}>{$LL.TOURNAMENTS.REGISTRATIONS.CHECK_OUT()}</Button>
+              <Button {working} size="xs" on:click={() => toggleCheckin(reg)}>{$LL.TOURNAMENTS.REGISTRATIONS.CHECK_OUT()}</Button>
             </div>
           {/if}
         {:else}

--- a/src/frontend/src/lib/components/tournaments/registration/MySquad.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/MySquad.svelte
@@ -30,6 +30,8 @@
   let registered_players = squad.players.filter((p) => !p.is_invite);
   let invited_players = squad.players.filter((p) => p.is_invite);
 
+  let working = false;
+
   let user_info: UserInfo;
   user.subscribe((value) => {
     user_info = value;
@@ -39,10 +41,10 @@
     if (!player) {
       return;
     }
-
     if (!my_player.is_squad_captain) {
       return;
     }
+    working = true;
     const payload = {
       squad_id: my_player.squad_id,
       player_id: player.id,
@@ -50,12 +52,12 @@
       is_bagger_clause: invite_as_bagger
     };
     const endpoint = `/api/tournaments/${tournament.id}/invitePlayer`;
-    console.log(payload);
     const response = await fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
+    working = false;
     const result = await response.json();
     if (response.status < 300) {
       window.location.reload();
@@ -91,6 +93,7 @@
   }
 
   async function editSquad(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+    working = true;
     const formData = new FormData(event.currentTarget);
     let squad_color = formData.get('squad_color');
     let squad_name = formData.get('squad_name');
@@ -102,12 +105,12 @@
       squad_tag: squad_tag,
     };
     const endpoint = `/api/tournaments/${tournament.id}/editMySquad`;
-    console.log(payload);
     const response = await fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
+    working = false;
     const result = await response.json();
     if (response.status < 300) {
       window.location.reload();
@@ -163,7 +166,7 @@
         </div>
       {/if}
       <div class="section">
-        <Button on:click={() => invitePlayer(invite_player)}>{$LL.TOURNAMENTS.REGISTRATIONS.INVITE_PLAYER()}</Button>
+        <Button {working} on:click={() => invitePlayer(invite_player)}>{$LL.TOURNAMENTS.REGISTRATIONS.INVITE_PLAYER()}</Button>
       </div>
     {/if}
   {/if}
@@ -184,7 +187,7 @@
     <SquadTournamentFields {tournament} squad_color={squad.color} squad_name={squad.name} squad_tag={squad.tag} />
     <br />
     <div>
-      <Button type="submit">{$LL.TOURNAMENTS.REGISTRATIONS.EDIT_SQUAD()}</Button>
+      <Button {working} type="submit">{$LL.TOURNAMENTS.REGISTRATIONS.EDIT_SQUAD()}</Button>
       <Button type="button" on:click={edit_squad_dialog.close}>{$LL.COMMON.CANCEL()}</Button>
     </div>
   </form>

--- a/src/frontend/src/lib/components/tournaments/registration/SoloSquadTournamentRegister.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/SoloSquadTournamentRegister.svelte
@@ -9,7 +9,10 @@
   export let tournament: Tournament;
   export let friend_codes: FriendCode[];
 
+  let working = false;
+
   async function registerSolo(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+    working = true;
     const formData = new FormData(event.currentTarget);
     let selected_fc_id = formData.get('selected_fc_id');
     let mii_name = formData.get('mii_name');
@@ -20,12 +23,12 @@
       can_host: can_host === 'true',
     };
     const endpoint = `/api/tournaments/${tournament.id}/register`;
-    console.log(payload);
     const response = await fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
+    working = false;
     const result = await response.json();
     if (response.status < 300) {
       window.location.reload();
@@ -35,6 +38,7 @@
     }
   }
   async function registerSquad(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+    working = true;
     const formData = new FormData(event.currentTarget);
     let squad_color = formData.get('squad_color');
     let squad_name = formData.get('squad_name');
@@ -53,12 +57,12 @@
       is_bagger_clause: is_bagger_clause === 'true',
     };
     const endpoint = `/api/tournaments/${tournament.id}/createSquad`;
-    console.log(payload);
     const response = await fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
+    working = false;
     const result = await response.json();
     if (response.status < 300) {
       window.location.reload();
@@ -84,8 +88,7 @@
       </select>
     </div>
   {/if}
-
-  <Button type="submit">{$LL.TOURNAMENTS.REGISTRATIONS.REGISTER()}</Button>
+  <Button type="submit" {working}>{$LL.TOURNAMENTS.REGISTRATIONS.REGISTER()}</Button>
 </form>
 
 <style>

--- a/src/frontend/src/lib/components/tournaments/registration/TeamTournamentRegister.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/TeamTournamentRegister.svelte
@@ -32,6 +32,7 @@
   let players: TeamTournamentPlayer[] = [];
 
   let squad_color = 1;
+  let working = false;
 
   let selected_player: RosterPlayer | null = null;
   $: unselected_rosters = rosters.filter((r) => !selected_rosters.includes(r));
@@ -148,6 +149,7 @@
   }
 
   async function register() {
+    working = true;
     const payload = {
       squad_color: squad_color,
       squad_name: selected_rosters[0].name,
@@ -156,12 +158,12 @@
       players: players
     };
     const endpoint = `/api/tournaments/${tournament.id}/${is_privileged ? 'forceRegisterTeam' : 'registerTeam'}`;
-    console.log(payload);
     const response = await fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
+    working = false;
     const result = await response.json();
     if (response.status < 300) {
       window.location.reload();
@@ -296,7 +298,7 @@
             {$LL.TOURNAMENTS.REGISTRATIONS.SELECT_LESS_PLAYERS({max_squad_size: tournament.max_squad_size, count: tournament.max_squad_size - players.length})}
           </div>
         {/if}
-        <Button on:click={register} disabled={!can_register}>{$LL.TOURNAMENTS.REGISTRATIONS.REGISTER()}</Button>
+        <Button on:click={register} {working} disabled={!can_register}>{$LL.TOURNAMENTS.REGISTRATIONS.REGISTER()}</Button>
       </div>
     {/if}
   </div>

--- a/src/frontend/src/lib/components/tournaments/registration/TournamentInviteList.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/TournamentInviteList.svelte
@@ -19,6 +19,7 @@
   let all_toggle_on = false;
   let accept_dialog: Dialog;
   let curr_invite: TournamentSquad;
+  let working = false;
 
   let user_info: UserInfo;
   user.subscribe((value) => {
@@ -51,6 +52,7 @@
     if (!curr_invite) {
       return;
     }
+    working = true;
     const formData = new FormData(event.currentTarget);
     let selected_fc_id = formData.get('selected_fc_id');
     let mii_name = formData.get('mii_name');
@@ -62,12 +64,12 @@
       squad_id: curr_invite.id,
     };
     const endpoint = `/api/tournaments/${tournament.id}/acceptInvite`;
-    console.log(payload);
     const response = await fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
+    working = false;
     const result = await response.json();
     if (response.status < 300) {
       window.location.reload();
@@ -178,7 +180,7 @@
       {/if}
       <br />
       <div>
-        <Button type="submit">{$LL.INVITES.ACCEPT()}</Button>
+        <Button {working} type="submit">{$LL.INVITES.ACCEPT()}</Button>
         <Button type="button" on:click={accept_dialog.close}>{$LL.COMMON.CANCEL()}</Button>
       </div>
     {/if}

--- a/src/frontend/src/lib/components/tournaments/series/CreateEditTournamentSeriesForm.svelte
+++ b/src/frontend/src/lib/components/tournaments/series/CreateEditTournamentSeriesForm.svelte
@@ -44,10 +44,13 @@
     }
   });
 
+  let working = false;
+
   function updateData() {
     data = data;
   }
   async function createSeries() {
+    working = true;
     let payload = data;
     console.log(payload);
     const endpoint = '/api/tournaments/series/create';
@@ -56,6 +59,7 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
+    working = false;
     const result = await response.json();
     if (response.status < 300) {
       goto(`/${$page.params.lang}/tournaments/series`);
@@ -65,6 +69,7 @@
     }
   }
   async function editSeries() {
+    working = true;
     data.series_id = series_id;
     let payload = data;
     console.log(payload);
@@ -74,6 +79,7 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
+    working = false;
     const result = await response.json();
     if (response.status < 300) {
       goto(`/${$page.params.lang}/tournaments/series/details?id=${series_id}`);
@@ -195,7 +201,7 @@
     </div>
   </Section>
   <Section header={$LL.COMMON.SUBMIT()}>
-    <Button type="submit">{is_edit ? $LL.TOURNAMENTS.SERIES.EDIT() : $LL.TOURNAMENTS.SERIES.CREATE()}</Button>
+    <Button type="submit" {working}>{is_edit ? $LL.TOURNAMENTS.SERIES.EDIT() : $LL.TOURNAMENTS.SERIES.CREATE()}</Button>
   </Section>
 </form>
 

--- a/src/frontend/src/lib/util/permissions.ts
+++ b/src/frontend/src/lib/util/permissions.ts
@@ -221,4 +221,5 @@ export const mod_panel_permissions = [
   permissions.manage_shadow_players,
   permissions.merge_players,
   permissions.merge_teams,
+  permissions.view_alt_flags,
 ];

--- a/src/frontend/src/routes/[lang]/moderator/manage_user_roles/+page.svelte
+++ b/src/frontend/src/routes/[lang]/moderator/manage_user_roles/+page.svelte
@@ -37,7 +37,7 @@
         {#if roles.length}
             <div class="select">
                 <select bind:value={selected_role}>
-                    {#each roles as role}
+                    {#each roles.toSorted((a, b) => a.position - b.position) as role}
                         <option value={role}>{role.name}</option>
                     {/each}
                 </select>

--- a/src/frontend/src/routes/[lang]/registry/players/profile/+page.svelte
+++ b/src/frontend/src/routes/[lang]/registry/players/profile/+page.svelte
@@ -41,6 +41,13 @@
 
   $: player_name = player ? player.name : 'Registry';
 
+  const mod_permissions = [
+    permissions.ban_player,
+    permissions.edit_player,
+    permissions.view_alt_flags,
+    permissions.edit_user,
+  ]
+
   onMount(async () => {
     let param_id = $page.url.searchParams.get('id');
     id = Number(param_id);
@@ -81,7 +88,7 @@
     <PlayerProfileBan ban_info={player.ban_info} />
   {/if}
 
-  {#if check_permission(user_info, permissions.ban_player) || check_permission(user_info, permissions.edit_player)}
+  {#if mod_permissions.some(p => check_permission(user_info, p))}
     <Section header={$LL.NAVBAR.MODERATOR()}>
       <div slot="header_content">
         {#if check_permission(user_info, permissions.ban_player)}

--- a/src/frontend/src/routes/[lang]/registry/teams/create/+page.svelte
+++ b/src/frontend/src/routes/[lang]/registry/teams/create/+page.svelte
@@ -20,8 +20,10 @@
 
   let tag = "";
   let logo_file = "";
+  let working = false;
 
   async function createTeam(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+    working = true;
     const data = new FormData(event.currentTarget);
     function getOptionalValue(name: string) {
       return data.get(name) ? data.get(name)?.toString() : '';
@@ -51,6 +53,7 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
+    working = false;
     const result = await response.json();
     if (response.status < 300) {
       let team_id = result['id'];
@@ -131,7 +134,7 @@
     </Section>
   {/if}
   <Section header={$LL.COMMON.SUBMIT()}>
-    <Button type="submit">{$LL.COMMON.SUBMIT()}</Button>
+    <Button type="submit" {working}>{$LL.COMMON.SUBMIT()}</Button>
   </Section>
 </form>
 

--- a/src/frontend/src/routes/[lang]/registry/teams/manage_roles/+page.svelte
+++ b/src/frontend/src/routes/[lang]/registry/teams/manage_roles/+page.svelte
@@ -48,7 +48,7 @@
         {#if roles.length}
             <div class="select">
                 <select bind:value={selected_role}>
-                    {#each roles as role}
+                    {#each roles.toSorted((a, b) => a.position - b.position) as role}
                         <option value={role}>{role.name}</option>
                     {/each}
                 </select>

--- a/src/frontend/src/routes/[lang]/time-trials/+page.svelte
+++ b/src/frontend/src/routes/[lang]/time-trials/+page.svelte
@@ -22,6 +22,7 @@
       </div>
     </div>
   </Section>
+  <hr/>
   <GameBadge game= "mk8dx" />
   <GameBadge game= "mk7" />
   <GameBadge game= "mkw" />
@@ -39,6 +40,7 @@
       </div>
     </div>
   </Section>
+  <hr/>
   <GameBadge game= "mkworld" />
   <GameBadge game= "mk8dx" />
   <GameBadge game = "mk8" />
@@ -58,6 +60,7 @@
       </div>
     </div>
   </Section>
+  <hr/>
   <GameBadge game= "mk8dx" />
   <Section header={'DLC Leaderboards'}>
     <div class="flex flex-row">
@@ -72,6 +75,7 @@
       </div>
     </div>
   </Section>
+  <hr/>
   <GameBadge game= "mk8dx" />
   <Section header={'No Item Leaderboards'}>
     <div class="flex flex-row">
@@ -94,6 +98,9 @@
     margin: 20px auto 20px auto;
   }
   .disclaimer {
+    margin-bottom: 20px;
+  }
+  hr {
     margin-bottom: 20px;
   }
 </style>

--- a/src/frontend/src/routes/[lang]/time-trials/+page.svelte
+++ b/src/frontend/src/routes/[lang]/time-trials/+page.svelte
@@ -10,6 +10,18 @@
     This page is currently a work in progress. For now,
     players can find leaderboards on several other sites.
   </div>
+  <GameBadge game="mkworld"/>
+  <Section header="Mario Kart World Time Trials">
+    <div class="flex flex-row">
+      <div class="flex flex-col justify-start">
+        <div class="mb-2 mx-2">
+          <Button size="lg" color="blue" href="https://discord.gg/6gDAPxvqh7">
+            <DiscordSolid class="mr-2" />Discord </Button
+          >
+        </div>
+      </div>
+    </div>
+  </Section>
   <GameBadge game= "mk8dx" />
   <GameBadge game= "mk7" />
   <GameBadge game= "mkw" />
@@ -27,6 +39,7 @@
       </div>
     </div>
   </Section>
+  <GameBadge game= "mkworld" />
   <GameBadge game= "mk8dx" />
   <GameBadge game = "mk8" />
   <GameBadge game= "mk7" />

--- a/src/frontend/src/routes/[lang]/tournaments/manage_roles/+page.svelte
+++ b/src/frontend/src/routes/[lang]/tournaments/manage_roles/+page.svelte
@@ -57,7 +57,7 @@
             {#if roles.length}
                 <div class="select">
                     <select bind:value={selected_role}>
-                        {#each roles as role}
+                        {#each roles.toSorted((a, b) => a.position - b.position) as role}
                             <option value={role}>{role.name}</option>
                         {/each}
                     </select>

--- a/src/frontend/src/routes/[lang]/tournaments/series/manage_roles/+page.svelte
+++ b/src/frontend/src/routes/[lang]/tournaments/series/manage_roles/+page.svelte
@@ -44,7 +44,7 @@
     {#if roles.length}
         <div class="select">
             <select bind:value={selected_role}>
-                {#each roles as role}
+                {#each roles.toSorted((a, b) => a.position - b.position) as role}
                     <option value={role}>{role.name}</option>
                 {/each}
             </select>

--- a/src/frontend/src/routes/[lang]/user/confirm-email/+page.svelte
+++ b/src/frontend/src/routes/[lang]/user/confirm-email/+page.svelte
@@ -7,7 +7,7 @@
     import { page } from "$app/stores";
     import LL from "$i18n/i18n-svelte";
 
-    let disable_button = false;
+    let working = false;
 
     let user_info: UserInfo;
 
@@ -45,13 +45,14 @@
     });
 
     async function send_confirmation_email() {
-        disable_button = true;
+        working = true;
         const endpoint = `/api/user/send_confirmation_email`;
         const response = await fetch(endpoint, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
         });
         const result = await response.json();
+        working = false;
         if(response.status < 300) {
             alert($LL.LOGIN.SEND_CONFIRMATION_EMAIL_SUCCESS());
         }
@@ -83,7 +84,7 @@
                 {$LL.LOGIN.EMAIL_CONFIRMATION_REQUIRED()}
             </div>
             <div class="section">
-                <Button disabled={disable_button} on:click={send_confirmation_email}>{$LL.LOGIN.SEND_CONFIRMATION_EMAIL()}</Button>
+                <Button {working} on:click={send_confirmation_email}>{$LL.LOGIN.SEND_CONFIRMATION_EMAIL()}</Button>
             </div>
         {/if}
     {/if}

--- a/src/frontend/src/routes/[lang]/user/player-signup/+page.svelte
+++ b/src/frontend/src/routes/[lang]/user/player-signup/+page.svelte
@@ -16,7 +16,10 @@
     user_info = value;
   });
 
+  let working = false;
+
   async function register(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }) {
+    working = true;
     const data = new FormData(event.currentTarget);
     const fc_labels = ['switch_fc', 'mkt_fc', 'mkw_fc', '3ds_fc', 'nnid'];
     const types = ['switch', 'mkt', 'mkw', '3ds', 'nnid'];
@@ -43,8 +46,8 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
+    working = false;
     const result = await response.json();
-
     if (response.status < 300) {
       goto('/');
       alert($LL.PLAYERS.PLAYER_SIGNUP.REGISTER_SUCCESS());
@@ -56,6 +59,8 @@
 
 {#if user_info.player_id !== null}
   {$LL.PLAYERS.PLAYER_SIGNUP.ALREADY_REGISTERED()}
+{:else if user_info.id === null}
+  {$LL.COMMON.LOGIN_REQUIRED()}
 {:else}
   <Section header={$LL.DISCORD.DISCORD()}>
     <LinkDiscord/>
@@ -104,7 +109,7 @@
         </span>
         <input name="nnid" placeholder='NNID'/>
       </div>
-      <Button type="submit">{$LL.PLAYERS.PLAYER_SIGNUP.REGISTER()}</Button>
+      <Button type="submit" {working}>{$LL.PLAYERS.PLAYER_SIGNUP.REGISTER()}</Button>
     </form>
   </Section>
 {/if}

--- a/src/frontend/src/routes/[lang]/user/privacy-policy/+page.svelte
+++ b/src/frontend/src/routes/[lang]/user/privacy-policy/+page.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <Section header="Privacy Policy">
-    <p>We are Mario Kart Central ("we", "our", "us"). We’re committed to protecting and respecting your privacy. If you have questions about your personal information please <a href="/forums/index.php?misc/contact">contact us</a>.</p>
+    <p>We are Mario Kart Central ("we", "our", "us"). We’re committed to protecting and respecting your privacy. If you have questions about your personal information please contact us.</p>
 
     <h2>What information we hold about you</h2>
     <p>The type of data that we collect and process includes:</p>
@@ -38,10 +38,10 @@
 
     <h2>Cookie policy</h2>
     <p>Cookies are small text files which are set by us on your computer which allow us to provide certain functionality on our site, such as being able to log in, or remembering certain preferences.</p>
-    <p>We have a detailed cookie policy and more information about the cookies that we set on <a href="/forums/index.php?help/cookies">this page</a>.</p>
+    <p>We have a detailed cookie policy and more information about the cookies that we set on this page.</p>
 
     <h2>Rights</h2>
-    <p>You have a right to access the personal data we hold about you or obtain a copy of it. To do so please <a href="/forums/index.php?misc/contact">contact us</a>. If you believe that the information we hold for you is incomplete or inaccurate, you may <a href="/forums/index.php?misc/contact">contact us</a> to ask us to complete or correct that information.</p>
+    <p>You have a right to access the personal data we hold about you or obtain a copy of it. To do so please contact us. If you believe that the information we hold for you is incomplete or inaccurate, you may contact us to ask us to complete or correct that information.</p>
     <p>You also have the right to request that your account be deleted, however, to ensure completeness of our event records, your messages, posts, and registry data will remain even if this is done. By signing up, you accept any data you submit may not be deleted.</p>
 
     <h2>Acceptance of this policy</h2>
@@ -51,5 +51,5 @@
     <p>We may make changes to this policy at any time. You may be asked to review and re-accept the information in this policy if it changes in the future.</p>
 
     <h2>CAPTCHA privacy policy</h2>
-    <p>This site is protected by hCaptcha and its <a href="https://hcaptcha.com/privacy" target="_blank">privacy policy</a> and <a href="https://hcaptcha.com/terms" target="_blank">terms of service</a> apply.</p>
+    <p>This site is protected by hCaptcha and its privacy policy and terms of service apply.</p>
 </Section>

--- a/src/frontend/src/routes/[lang]/user/privacy-policy/+page.svelte
+++ b/src/frontend/src/routes/[lang]/user/privacy-policy/+page.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+    import Section from "$lib/components/common/Section.svelte";
+</script>
+
+<Section header="Privacy Policy">
+    <p>We are Mario Kart Central ("we", "our", "us"). We’re committed to protecting and respecting your privacy. If you have questions about your personal information please <a href="/forums/index.php?misc/contact">contact us</a>.</p>
+
+    <h2>What information we hold about you</h2>
+    <p>The type of data that we collect and process includes:</p>
+    <ul>
+        <li>Your name or username.</li>
+        <li>Your email address.</li>
+        <li>Your IP address.</li>
+    </ul>
+    <p>Further data may be collected if you choose to share it, such as if you fill out fields on your profile.</p>
+    <p>We collect some or all of this information in the following cases:</p>
+    <ul>
+        <li>You register as a member on this site.</li>
+        <li>You fill out our contact form.</li>
+        <li>You browse this site. See "Cookie policy" below.</li>
+        <li>You fill out fields on your profile.</li>
+    </ul>
+
+    <h2>How your personal information is used</h2>
+    <p>We may use your personal information in the following ways:</p>
+    <ul>
+        <li>For the purposes of making you a registered member of our site, in order for you to contribute content to this site.</li>
+        <li>We may use your email address to inform you of activity on our site.</li>
+        <li>Your IP address is recorded when you perform certain actions on our site. Your IP address is never publicly visible.</li>
+    </ul>
+
+    <h2>Other ways we may use your personal information.</h2>
+    <p>In addition to notifying you of activity on our site which may be relevant to you, from time to time we may wish to communicate with all members any important information such as newsletters or announcements by email. You can opt-in to or opt-out of such emails in your profile.</p>
+    <p>We may collect non-personally identifiable information about you in the course of your interaction with our site. This information may include technical information about the browser or type of device you're using. This information will be used purely for the purposes of analytics and tracking the number of visitors to our site.</p>
+
+    <h2>Keeping your data secure</h2>
+    <p>We are committed to ensuring that any information you provide to us is secure. In order to prevent unauthorized access or disclosure, we have put in place suitable measures and procedures to safeguard and secure the information that we collect.</p>
+
+    <h2>Cookie policy</h2>
+    <p>Cookies are small text files which are set by us on your computer which allow us to provide certain functionality on our site, such as being able to log in, or remembering certain preferences.</p>
+    <p>We have a detailed cookie policy and more information about the cookies that we set on <a href="/forums/index.php?help/cookies">this page</a>.</p>
+
+    <h2>Rights</h2>
+    <p>You have a right to access the personal data we hold about you or obtain a copy of it. To do so please <a href="/forums/index.php?misc/contact">contact us</a>. If you believe that the information we hold for you is incomplete or inaccurate, you may <a href="/forums/index.php?misc/contact">contact us</a> to ask us to complete or correct that information.</p>
+    <p>You also have the right to request that your account be deleted, however, to ensure completeness of our event records, your messages, posts, and registry data will remain even if this is done. By signing up, you accept any data you submit may not be deleted.</p>
+
+    <h2>Acceptance of this policy</h2>
+    <p>Continued use of our site signifies your acceptance of this policy. If you do not accept the policy then please do not use this site. When registering we will further request your explicit acceptance of the privacy policy.</p>
+
+    <h2>Changes to this policy</h2>
+    <p>We may make changes to this policy at any time. You may be asked to review and re-accept the information in this policy if it changes in the future.</p>
+
+    <h2>CAPTCHA privacy policy</h2>
+    <p>This site is protected by hCaptcha and its <a href="https://hcaptcha.com/privacy" target="_blank">privacy policy</a> and <a href="https://hcaptcha.com/terms" target="_blank">terms of service</a> apply.</p>
+</Section>

--- a/src/frontend/src/routes/[lang]/user/terms/+page.svelte
+++ b/src/frontend/src/routes/[lang]/user/terms/+page.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+    import Section from "$lib/components/common/Section.svelte";
+</script>
+
+<Section header="Terms of Service">
+    <p>The providers ("we", "us", "our") of the service provided by this web site ("MKCentral", "Website") are not responsible for any user-generated content and accounts. Content submitted express the views of their author only.</p>
+
+    <p>MKCentral is only available to users who are at least 13 years old. If you are younger than this, please do not register for MKCentral. If you register for MKCentral, you represent that you are this age or older.
+    </p>
+
+    <p>All content you submit, upload, or otherwise make available to MKCentral ("Content") may be reviewed by staff members. All Content you submit or upload may be sent to third-party verification services (including, but not limited to, spam prevention services). Do not submit any Content that you consider to be private or confidential.
+    </p>
+
+    <p>You agree to not use MKCentral to submit or link to any Content which is defamatory, abusive, hateful, threatening, spam or spam-like, likely to offend, contains adult or objectionable content, contains personal information of others, risks copyright infringement, encourages unlawful activity, or otherwise violates any laws. You are entirely responsible for the content of, and any harm resulting from, that Content or your conduct.</p>
+
+    <p>We may remove or modify any Content submitted at any time, with or without cause, with or without notice. Requests for Content to be removed or modified will be undertaken only at our discretion. We may terminate your access to all or any part of MKCentral at any time, with or without cause, with or without notice.</p>
+
+    <p>You are granting us with a non-exclusive, permanent, irrevocable, unlimited license to use, publish, or re-publish your Content in connection with MKCentral. You retain copyright over the Content.
+    </p>
+
+    <p>You agree to follow the rules as enforced by our staff. If you are caught breaking these rules, your account(s) may be banned and you may no longer use MKCentral.
+    </p>
+
+    <p>You may only create one account. <b>If you create multiple accounts (“alting”), all of your accounts will be banned indefinitely.</b></p>
+
+    <p>If your account is deleted, you may not create another account for a one-year period following the deletion. Any new accounts you create within one year will be banned or deleted.</p>
+
+    <p>You agree not to hack, reverse engineer, or otherwise abuse, or disrupt normal operations of MKCentral. Offenders will have their accounts banned by MKCentral staff.</p>
+
+    <p>MKCentral is used as a place to compete in video game tournaments and events including for Mario Kart 8 Deluxe. Users found to be cheating or otherwise maliciously interfering with the game in question will be banned at the discretion of MKCentral staff.</p>
+
+    <p>You agree not to harrass, target with defamatory content, or reveal private personal information about (including, but not limited to, location, full name, or email address) other members of this Website, <b>including on third party services</b>, such as Discord or Twitter, or other channels of communication. Users found to be engaging in this type of activity may have their accounts banned at the discretion of MKCentral staff.</p>
+
+    <p>Use of the MKCentral registry is covered by these Terms. Users found to be using the registry in ways deemed unacceptable by MKCentral staff, including inputting spam or offensive content, or manipulating MKCentral-hosted events’ and leagues’ rules, will be banned at the discretion of MKCentral staff.</p>
+
+    <p>These terms may be changed at any time without notice. Users of MKCentral are subject to the modified terms when they are changed.</p>
+
+    <p>If you do not agree with these terms, please do not register or use the Service. Use of the Service and/or participation in Mario Kart Central tournaments constitutes acceptance of these terms. If you wish to deactivate your account, please <a href="https://discord.gg/x2Q2339rhV">contact us</a>.</p>
+
+    - 
+
+    <p>この Web サイト (以下「MKCentral」) が提供するサービスの提供者 (以下｢本コミュニティ｣) は、ユーザーが作成したコンテンツおよびアカウントについて一切責任を負いません。投稿されたコンテンツは、その作成者の意見のみを表明するものです。</p>
+
+    <p>MKCentral は、13歳以上のユーザーのみが利用できます。この年齢未満の場合は、MKCentral に登録しないでください。MKCentral に登録すると、この年齢以上であることを表明したことになります。
+    </p>
+
+    <p>MKCentral に送信、アップロード、またはその他の方法で提供したすべてのコンテンツ (「コンテンツ」) は、スタッフ メンバーによって確認される場合があります。送信またはアップロードしたすべてのコンテンツは、サードパーティの検証サービス (スパム防止サービスを含むがこれに限定されない) に送信されることがあります。プライベートまたは機密であると考えられるコンテンツは送信しないでください。
+    </p>
+
+    <p>ご利用者様は、中傷的、虐待的、憎悪的、脅迫的、スパムまたはスパムに類似する、不快感を与える可能性のある、成人向けまたは不快なコンテンツを含む、他者の個人情報を含む、著作権侵害のリスクがある、違法行為を奨励する、またはその他の法律に違反するコンテンツを送信またはリンクするために MKCentral を使用しないことに同意します。ご利用者様は、そのコンテンツの内容、およびコンテンツまたはご利用者様の行為から生じるあらゆる損害について全責任を負います。</p>
+
+    <p>本コミュニティは、理由の有無、通知の有無にかかわらず、いつでも送信されたコンテンツを削除または変更することができます。コンテンツの削除または変更のリクエストは、本コミュニティの裁量でのみ行われます。本コミュニティは、理由の有無、通知の有無にかかわらず、いつでも MKCentral の全体または一部へのご利用者様のアクセスを終了することができます。</p>
+
+    <p>ご利用者様は、MKCentral に関連してお客様のコンテンツを使用、公開、または再公開するための非独占的、永続的、取消不能、無制限のライセンスを当社に付与します。 コンテンツの著作権はご利用者様が保持します。
+    </p>
+
+    <p>ご利用者様は、本コミュニティのスタッフが施行する規則に従うことに同意します。これらの規則に違反していることが判明した場合、ご利用者様のアカウントは停止され、MKCentral を使用できなくなります。
+    </p>
+
+    <p>ご利用者様は、1 つのアカウントのみを作成できます。<b>複数のアカウントを作成した場合 (「alting」)、すべてのアカウントが無期限に停止されます。</b></p>
+
+    <p>ご利用者様のアカウントが削除された場合、削除後 1 年間は別のアカウントを作成することはできません。1 年以内に作成した新しいアカウントは停止または削除されます。</p>
+
+    <p>ご利用者様は、MKCentral のハッキング、リバース エンジニアリング、またはその他の不正使用、または通常の運用の妨害を行わないことに同意します。違反者は、MKCentral スタッフによってアカウントが停止されます。</p>
+
+    <p>MKCentral は、マリオ カート 8 デラックスを含むビデオ ゲームのトーナメントやイベントで競う場として使用されます。 不正行為や、ゲームへの悪意ある干渉が判明したユーザーは、MKCentral スタッフの裁量によりアカウントが停止されます。</p>
+
+    <p>お客様は、Discord や Twitter などのサードパーティ サービスやその他の通信チャネルを含む、この Web サイトの他のご利用者様への嫌がらせ、中傷的なコンテンツでの標的化、個人情報 (住所、氏名、メール アドレスなど) を公開を行わないことに同意します。この種の活動に関与していることが判明したユーザーは、MKCentral スタッフの裁量によりアカウントが停止される場合があります。</p>
+
+    <p>MKCentral レジストリの使用は、本規約の対象となります。 スパムや不快なコンテンツを入力する、MKCentral が主催する大会やリーグのルールを操作するなど、MKCentral スタッフが容認できないと判断する方法でレジストリを使用していることが判明したユーザーは、MKCentral スタッフの裁量によりアカウントが停止されます。</p>
+
+    <p>これらの条件は、予告なしにいつでも変更される場合があります。MKCentral のユーザーは、変更された条件に従う必要があります。</p>
+
+    <p>これらの条件に同意しない場合は、サービスに登録または使用しないでください。サービスの使用および/または Mario Kart Central トーナメントへの参加は、これらの条件に同意したものとみなされます。アカウントを無効にしたい場合は、<a href="https://discord.gg/x2Q2339rhV">お問い合わせください</a>。</p>
+</Section>

--- a/src/frontend/src/routes/[lang]/user/terms/+page.svelte
+++ b/src/frontend/src/routes/[lang]/user/terms/+page.svelte
@@ -35,7 +35,7 @@
 
     <p>These terms may be changed at any time without notice. Users of MKCentral are subject to the modified terms when they are changed.</p>
 
-    <p>If you do not agree with these terms, please do not register or use the Service. Use of the Service and/or participation in Mario Kart Central tournaments constitutes acceptance of these terms. If you wish to deactivate your account, please <a href="https://discord.gg/x2Q2339rhV">contact us</a>.</p>
+    <p>If you do not agree with these terms, please do not register or use the Service. Use of the Service and/or participation in Mario Kart Central tournaments constitutes acceptance of these terms. If you wish to deactivate your account, please contact us.</p>
 
     - 
 
@@ -71,5 +71,5 @@
 
     <p>これらの条件は、予告なしにいつでも変更される場合があります。MKCentral のユーザーは、変更された条件に従う必要があります。</p>
 
-    <p>これらの条件に同意しない場合は、サービスに登録または使用しないでください。サービスの使用および/または Mario Kart Central トーナメントへの参加は、これらの条件に同意したものとみなされます。アカウントを無効にしたい場合は、<a href="https://discord.gg/x2Q2339rhV">お問い合わせください</a>。</p>
+    <p>これらの条件に同意しない場合は、サービスに登録または使用しないでください。サービスの使用および/または Mario Kart Central トーナメントへの参加は、これらの条件に同意したものとみなされます。アカウントを無効にしたい場合は、お問い合わせください。</p>
 </Section>

--- a/src/frontend/src/routes/[lang]/user/transfer-account/+page.svelte
+++ b/src/frontend/src/routes/[lang]/user/transfer-account/+page.svelte
@@ -18,6 +18,7 @@
 
     async function transfer_account() {
         if(!player) return;
+        working = true;
         const payload = {
             player_id: player.id,
         };
@@ -27,6 +28,7 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
+        working = false;
         const result = await response.json();
         if(response.status < 300) {
             alert($LL.LOGIN.TRANSFER_ACCOUNT_SUCCESS());
@@ -52,7 +54,7 @@
             </div>
             {#if player}
                 <div>
-                    <Button disabled={working} on:click={transfer_account}>{$LL.LOGIN.TRANSFER_ACCOUNT()}</Button>
+                    <Button {working} on:click={transfer_account}>{$LL.LOGIN.TRANSFER_ACCOUNT()}</Button>
                 </div>
             {/if}
         </Section>

--- a/src/frontend/svelte.config.js
+++ b/src/frontend/svelte.config.js
@@ -70,7 +70,9 @@ function getEntriesForLocale(locale) {
     `/${locale}/user/login`,
     `/${locale}/user/notifications`,
     `/${locale}/user/player-signup`,
+    `/${locale}/user/privacy-policy`,
     `/${locale}/user/reset-password`,
+    `/${locale}/user/terms`,
   ];
 }
 


### PR DESCRIPTION
- Added [asgi-ratelimit](https://github.com/abersheeran/asgi-ratelimit) middleware to rate limit certain endpoints, such as endpoints that send emails or have image uploads
- I went for 3/minute, 10/hour limits for now, let me know if I should pick something different
- The following text displays when you are ratelimited from a certain endpoint:
![image](https://github.com/user-attachments/assets/58546e57-345b-4501-befb-f1ea1e72c4cc)
- Added a check to make sure users can't request to create 2 teams at the same time
- Added Lounge Staff role with the permission to view alt flags so that Lounge admins can catch alts
- Fixed clicking the "cancel" button in the Discord linking process to just redirect back to the website
- Added a `working` parameter to the Button component which allows us to prevent double clicks on most endpoints that create new entities, such as registering, creating new teams, tournaments, etc. The first thing most `on:click` handlers do is set `working` to true before you have the chance to double click, and back to false once the action is completed. If `working` is true for a button, it will be disabled and show a loading icon:
![image](https://github.com/user-attachments/assets/92f252fc-52f4-4082-bdb9-e0ee073f7fb2)
- Added placeholder terms of service and privacy policy pages (for now I just used the current MKC's terms of service and policy policy). Users must agree to the terms on registering (or resetting their password from email, so that users who transfer their account from the old site still have to agree). The text next to the checkboxes links to the terms of service and privacy policy respectively:
![image](https://github.com/user-attachments/assets/23d0b6ec-0637-4c2d-ae05-36df14e51acd)
