### PR TITLE
Refactor tournaments

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -256,13 +256,14 @@ erDiagram
 ```mermaid
 erDiagram
     %% Registration
-    Tournament ||--o{ TournamentSquad : "hosts"
-    TournamentSquad ||--o{ TournamentPlayer : "includes"
+    Tournament ||--o{ TournamentRegistration : "hosts"
+    TournamentRegistration ||--o{ TournamentPlayer : "includes"
     Player ||--o{ TournamentPlayer : "competes"
 ```
 
-**TournamentSquad**
-- Manages team-based tournament participation
+**TournamentRegistration**
+- Catch-all for solo, squad, team registrations for tournaments
+- Manages tournament participation
 - Represents groups competing together
 
 **TournamentPlayer**
@@ -274,18 +275,13 @@ erDiagram
 ```mermaid
 erDiagram
     %% Placements
-    Tournament ||--o{ TournamentSoloPlacements : "ranks"
-    Tournament ||--o{ TournamentSquadPlacements : "ranks"
-    TournamentSquad ||--|| TournamentSquadPlacements : "achieves"
+    Tournament ||--o{ TournamentPlacements : "ranks"
+    TournamentRegistration ||--|| TournamentPlacements : "achieves"
 ```
 
-**TournamentSoloPlacements**
-- Records individual tournament results
-- Tracks player performance in solo events
-
-**TournamentSquadPlacements**
-- Manages team-based tournament results
-- Captures squad performance metrics
+**TournamentPlacements**
+- Records tournament results
+- Tracks player/squad/team performance in events
 
 ## Administrative Systems
 

--- a/src/backend/api/endpoints/tournament_placements.py
+++ b/src/backend/api/endpoints/tournament_placements.py
@@ -11,17 +11,9 @@ from common.data.models import *
 @require_tournament_permission(tournament_permissions.MANAGE_PLACEMENTS)
 async def set_placements(request: Request, body: list[TournamentPlacement]) -> JSONResponse:
     tournament_id = int(request.path_params['tournament_id'])
-    command = CheckIfSquadTournament(tournament_id)
-    is_squad = await handle(command)
-    if is_squad:
-        reg_command = GetSquadRegistrationsCommand(tournament_id, False, False, False, None)
-        registrations = await handle(reg_command)
-        placements_command = SetSquadPlacementsCommand(tournament_id, body, registrations)
-    else:
-        reg_command = GetFFARegistrationsCommand(tournament_id, False, False, None)
-        registrations = await handle(reg_command)
-        placements_command = SetSoloPlacementsCommand(tournament_id, body, registrations)
-
+    reg_command = GetTournamentRegistrationsCommand(tournament_id, False, False, False, None)
+    registrations = await handle(reg_command)
+    placements_command = SetTournamentPlacementsCommand(tournament_id, body, registrations)
     await handle(placements_command)
 
     return JSONResponse({})
@@ -30,25 +22,17 @@ async def set_placements(request: Request, body: list[TournamentPlacement]) -> J
 @require_tournament_permission(tournament_permissions.MANAGE_PLACEMENTS)
 async def set_placements_from_player_ids(request: Request, body: list[TournamentPlacementFromPlayerIDs]) -> JSONResponse:
     tournament_id = int(request.path_params['tournament_id'])
-    command = SetSquadPlacementsFromPlayerIDsCommand(tournament_id, body)
+    command = SetTournamentPlacementsFromPlayerIDsCommand(tournament_id, body)
     await handle(command)
     return JSONResponse({})
 
 @check_tournament_visiblity
 async def get_placements(request: Request) -> JSONResponse:
     tournament_id = int(request.path_params['tournament_id'])
-    command = CheckIfSquadTournament(tournament_id)
-    is_squad = await handle(command)
-    if is_squad:
-        reg_command = GetSquadRegistrationsCommand(tournament_id, False, False, False, None)
-        squads = await handle(reg_command)
-        placements_command = GetSquadPlacementsCommand(tournament_id, squads)
-        placements = await handle(placements_command)
-    else:
-        reg_command = GetFFARegistrationsCommand(tournament_id, False, False, None)
-        players = await handle(reg_command)
-        placements_command = GetSoloPlacementsCommand(tournament_id, players)
-        placements = await handle(placements_command)
+    reg_command = GetTournamentRegistrationsCommand(tournament_id, False, False, False, None)
+    squads = await handle(reg_command)
+    placements_command = GetTournamentPlacementsCommand(tournament_id, squads)
+    placements = await handle(placements_command)
     
     return JSONResponse(placements)
 

--- a/src/backend/api/endpoints/tournament_registration.py
+++ b/src/backend/api/endpoints/tournament_registration.py
@@ -43,15 +43,15 @@ async def register_my_team(request: Request, body: RegisterTeamRequestData) -> J
 @require_tournament_permission(tournament_permissions.MANAGE_TOURNAMENT_REGISTRATIONS)
 async def force_register_team(request: Request, body: RegisterTeamRequestData) -> JSONResponse:
     async def notify():
-        if squad_id:
-            data = await handle(GetNotificationSquadDataCommand(tournament_id, squad_id))
+        if registration_id:
+            data = await handle(GetNotificationSquadDataCommand(tournament_id, registration_id))
             await handle(DispatchNotificationCommand([data.captain_user_id], notifications.STAFF_REGISTER_TEAM, {'tournament_name': data.tournament_name}, f'/tournaments/details?id={tournament_id}', notifications.SUCCESS))
 
     tournament_id = request.path_params['tournament_id']
     player_id = request.state.user.player_id
     command = RegisterTeamTournamentCommand(tournament_id, body.squad_name, body.squad_tag, body.squad_color,
                                             player_id, body.roster_ids, body.players, True, is_privileged=True)
-    squad_id = await handle(command)
+    registration_id = await handle(command)
     return JSONResponse({}, background=BackgroundTask(notify))
 
 # endpoint used when a tournament staff creates a squad with another user in it
@@ -77,7 +77,7 @@ async def force_create_squad(request: Request, body: ForceCreateSquadRequestData
 @require_tournament_permission(tournament_permissions.MANAGE_TOURNAMENT_REGISTRATIONS)
 async def edit_squad(request: Request, body: EditSquadRequestData) -> JSONResponse:
     tournament_id = request.path_params['tournament_id']
-    command = EditSquadCommand(tournament_id, body.squad_id, body.squad_name, body.squad_tag, body.squad_color, body.is_registered, body.is_approved)
+    command = EditSquadCommand(tournament_id, body.registration_id, body.squad_name, body.squad_tag, body.squad_color, body.is_registered, body.is_approved)
     await handle(command)
     return JSONResponse({})
 
@@ -87,9 +87,9 @@ async def edit_squad(request: Request, body: EditSquadRequestData) -> JSONRespon
 async def edit_my_squad(request: Request, body: EditMySquadRequestData) -> JSONResponse:
     tournament_id = request.path_params['tournament_id']
     captain_player_id = request.state.user.player_id
-    command = CheckSquadCaptainPermissionsCommand(tournament_id, body.squad_id, captain_player_id)
+    command = CheckSquadCaptainPermissionsCommand(tournament_id, body.registration_id, captain_player_id)
     await handle(command)
-    command = EditSquadCommand(tournament_id, body.squad_id, body.squad_name, body.squad_tag, body.squad_color, True, None)
+    command = EditSquadCommand(tournament_id, body.registration_id, body.squad_name, body.squad_tag, body.squad_color, True, None)
     await handle(command)
     return JSONResponse({})
 
@@ -102,15 +102,15 @@ async def invite_player(request: Request, body: InvitePlayerRequestData) -> JSON
         user_id = await handle(GetUserIdFromPlayerIdCommand(body.player_id))
         if user_id is None:
             return
-        data = await handle(GetNotificationSquadDataCommand(tournament_id, body.squad_id))
+        data = await handle(GetNotificationSquadDataCommand(tournament_id, body.registration_id))
         content_args = {'squad_name': data.squad_name or '', 'tournament_name': data.tournament_name}
         await handle(DispatchNotificationCommand([user_id], notifications.TOURNAMENT_INVITE , content_args, '/registry/invites', notifications.SUCCESS))
 
     tournament_id = request.path_params['tournament_id']
     captain_player_id = request.state.user.player_id
-    command = CheckSquadCaptainPermissionsCommand(tournament_id, body.squad_id, captain_player_id)
+    command = CheckSquadCaptainPermissionsCommand(tournament_id, body.registration_id, captain_player_id)
     await handle(command)
-    command = RegisterPlayerCommand(body.player_id, tournament_id, body.squad_id, False, False, None, False, True, None, body.is_representative, body.is_bagger_clause, False, False)
+    command = RegisterPlayerCommand(body.player_id, tournament_id, body.registration_id, False, False, None, False, True, None, body.is_representative, body.is_bagger_clause, False, False)
     await handle(command)
     return JSONResponse({}, background=BackgroundTask(notify))
 
@@ -139,14 +139,14 @@ async def force_register_player(request: Request, body: ForceRegisterPlayerReque
         if user_id is None:
             return
         player_name = await handle(GetPlayerNameCommand(body.player_id))
-        if body.squad_id:
-            data = await handle(GetNotificationSquadDataCommand(tournament_id, body.squad_id))
+        if body.registration_id:
+            data = await handle(GetNotificationSquadDataCommand(tournament_id, body.registration_id))
             content_args = {'player_name': player_name, 'tournament_name': data.tournament_name}
             await handle(DispatchNotificationCommand([data.captain_user_id], notifications.TOURNAMENT_STAFF_REGISTERED_CAPTAIN_NOTIF , content_args, f'/tournaments/details?id={tournament_id}', notifications.INFO))
             await handle(DispatchNotificationCommand([user_id], notifications.TOURNAMENT_STAFF_REGISTERED , {'tournament_name': data.tournament_name}, f'/tournaments/details?id={tournament_id}', notifications.SUCCESS))
 
     tournament_id = request.path_params['tournament_id']
-    command = RegisterPlayerCommand(body.player_id, tournament_id, body.squad_id, body.is_squad_captain, body.is_checked_in, 
+    command = RegisterPlayerCommand(body.player_id, tournament_id, body.registration_id, body.is_squad_captain, body.is_checked_in, 
         body.mii_name, body.can_host, body.is_invite, body.selected_fc_id, body.is_representative, body.is_bagger_clause, body.is_approved, True)
     await handle(command)
     return JSONResponse({}, background=BackgroundTask(notify))
@@ -163,7 +163,7 @@ async def edit_registration(request: Request, body: EditPlayerRegistrationReques
         await handle(DispatchNotificationCommand([user_id], notifications.STAFF_EDIT_PLAYER_REGISTRATION , {'tournament_name': tournament_name}, f'/tournaments/details?id={tournament_id}', notifications.INFO))
 
     tournament_id = request.path_params['tournament_id']
-    command = EditPlayerRegistrationCommand(tournament_id, body.squad_id, body.player_id, body.mii_name, body.can_host,
+    command = EditPlayerRegistrationCommand(tournament_id, body.registration_id, body.player_id, body.mii_name, body.can_host,
         body.is_invite, body.is_checked_in, body.is_squad_captain, body.selected_fc_id, body.is_representative, 
         body.is_bagger_clause, body.is_approved, True)
     await handle(command)
@@ -179,7 +179,7 @@ async def edit_my_registration(request: Request, body: EditMyRegistrationRequest
                                                                         tournament_id=tournament_id))
     if body.can_host and not player_host_permission:
         raise Problem("User does not have permission to register as a host", status=401)
-    command = EditPlayerRegistrationCommand(tournament_id, body.squad_id, player_id, body.mii_name, body.can_host, False, None, None, body.selected_fc_id,
+    command = EditPlayerRegistrationCommand(tournament_id, body.registration_id, player_id, body.mii_name, body.can_host, False, None, None, body.selected_fc_id,
                                             None, None, None, False)
     await handle(command)
     return JSONResponse({})
@@ -190,7 +190,7 @@ async def edit_my_registration(request: Request, body: EditMyRegistrationRequest
 async def accept_invite(request: Request, body: AcceptInviteRequestData) -> JSONResponse:
     async def notify():
         player_name = await handle(GetPlayerNameCommand(player_id))
-        data = await handle(GetNotificationSquadDataCommand(tournament_id, body.squad_id))
+        data = await handle(GetNotificationSquadDataCommand(tournament_id, body.registration_id))
         content_args = {'player_name': player_name, 'tournament_name': data.tournament_name}
         await handle(DispatchNotificationCommand([data.captain_user_id], notifications.TOURNAMENT_INVITE_ACCEPTED , content_args, f'/tournaments/details?id={tournament_id}', notifications.SUCCESS))
 
@@ -201,7 +201,7 @@ async def accept_invite(request: Request, body: AcceptInviteRequestData) -> JSON
     if body.can_host and not player_host_permission:
         raise Problem("User does not have permission to register as a host", status=401)
     
-    command = EditPlayerRegistrationCommand(tournament_id, body.squad_id, player_id, body.mii_name, body.can_host,
+    command = EditPlayerRegistrationCommand(tournament_id, body.registration_id, player_id, body.mii_name, body.can_host,
         False, False, False, body.selected_fc_id, None, None, None, False)
     await handle(command)
     return JSONResponse({}, background=BackgroundTask(notify))
@@ -210,14 +210,14 @@ async def accept_invite(request: Request, body: AcceptInviteRequestData) -> JSON
 @require_logged_in
 async def decline_invite(request: Request, body: DeclineInviteRequestData) -> JSONResponse:
     async def notify():
-        data = await handle(GetNotificationSquadDataCommand(tournament_id, body.squad_id))
+        data = await handle(GetNotificationSquadDataCommand(tournament_id, body.registration_id))
         player_name = await handle(GetPlayerNameCommand(player_id))
         content_args = {'player_name': player_name, 'squad_name': data.squad_name or data.tournament_name}
         await handle(DispatchNotificationCommand([data.captain_user_id], notifications.DECLINE_SQUAD_INVITE , content_args, f'/tournaments/details?id={tournament_id}', notifications.WARNING))
 
     tournament_id = request.path_params['tournament_id']
     player_id = request.state.user.player_id
-    command = UnregisterPlayerCommand(tournament_id, body.squad_id, player_id, False)
+    command = UnregisterPlayerCommand(tournament_id, body.registration_id, player_id, False)
     await handle(command)
     return JSONResponse({}, background=BackgroundTask(notify))
 
@@ -229,15 +229,15 @@ async def remove_player_from_squad(request: Request, body: KickSquadPlayerReques
         user_id = await handle(GetUserIdFromPlayerIdCommand(body.player_id))
         if user_id is None:
             return
-        data = await handle(GetNotificationSquadDataCommand(tournament_id, body.squad_id))
+        data = await handle(GetNotificationSquadDataCommand(tournament_id, body.registration_id))
         content_args = {'squad_name': data.squad_name or data.tournament_name}
         await handle(DispatchNotificationCommand([user_id], notifications.TOURNAMENT_KICKED , content_args, f'/tournaments/details?id={tournament_id}', notifications.WARNING))
 
     tournament_id = request.path_params['tournament_id']
     captain_player_id = request.state.user.player_id
-    command = CheckSquadCaptainPermissionsCommand(tournament_id, body.squad_id, captain_player_id)
+    command = CheckSquadCaptainPermissionsCommand(tournament_id, body.registration_id, captain_player_id)
     await handle(command)
-    command = UnregisterPlayerCommand(tournament_id, body.squad_id, body.player_id, False)
+    command = UnregisterPlayerCommand(tournament_id, body.registration_id, body.player_id, False)
     await handle(command)
     return JSONResponse({}, background=BackgroundTask(notify))
 
@@ -247,7 +247,7 @@ async def remove_player_from_squad(request: Request, body: KickSquadPlayerReques
 async def unregister_me(request: Request, body: UnregisterPlayerRequestData) -> JSONResponse:
     tournament_id = request.path_params['tournament_id']
     player_id = request.state.user.player_id
-    command = UnregisterPlayerCommand(tournament_id, body.squad_id, player_id, False)
+    command = UnregisterPlayerCommand(tournament_id, body.registration_id, player_id, False)
     await handle(command)
     return JSONResponse({})
 
@@ -260,14 +260,14 @@ async def staff_unregister(request: Request, body: StaffUnregisterPlayerRequestD
         if user_id is None:
             return
         player_name = await handle(GetPlayerNameCommand(body.player_id))
-        if body.squad_id:
-            data = await handle(GetNotificationSquadDataCommand(tournament_id, body.squad_id))
+        if body.registration_id:
+            data = await handle(GetNotificationSquadDataCommand(tournament_id, body.registration_id))
             content_args = {'player_name': player_name, 'tournament_name': data.tournament_name}
             await handle(DispatchNotificationCommand([data.captain_user_id], notifications.TOURNAMENT_STAFF_UNREGISTERED_CAPTAIN_NOTIF , content_args, f'/tournaments/details?id={tournament_id}', notifications.WARNING))
             await handle(DispatchNotificationCommand([user_id], notifications.TOURNAMENT_STAFF_UNREGISTERED , {'tournament_name': data.tournament_name}, f'/tournaments/details?id={tournament_id}', notifications.WARNING))
 
     tournament_id = request.path_params['tournament_id']
-    command = UnregisterPlayerCommand(tournament_id, body.squad_id, body.player_id, True)
+    command = UnregisterPlayerCommand(tournament_id, body.registration_id, body.player_id, True)
     await handle(command)
     return JSONResponse({}, background=BackgroundTask(notify))
 
@@ -278,15 +278,15 @@ async def change_squad_captain(request: Request, body: MakeCaptainRequestData) -
         user_id = await handle(GetUserIdFromPlayerIdCommand(body.player_id))
         if user_id is None:
             return
-        data = await handle(GetNotificationSquadDataCommand(tournament_id, body.squad_id))
+        data = await handle(GetNotificationSquadDataCommand(tournament_id, body.registration_id))
         content_args = {'squad_name': data.squad_name or data.tournament_name}
         await handle(DispatchNotificationCommand([user_id], notifications.CHANGE_SQUAD_CAPTAIN, content_args, f'/tournaments/details?id={tournament_id}', notifications.SUCCESS))
 
     tournament_id = request.path_params['tournament_id']
     captain_player_id = request.state.user.player_id
-    command = CheckSquadCaptainPermissionsCommand(tournament_id, body.squad_id, captain_player_id)
+    command = CheckSquadCaptainPermissionsCommand(tournament_id, body.registration_id, captain_player_id)
     await handle(command)
-    command = ChangeSquadCaptainCommand(tournament_id, body.squad_id, body.player_id)
+    command = ChangeSquadCaptainCommand(tournament_id, body.registration_id, body.player_id)
     await handle(command)
     return JSONResponse({}, background=BackgroundTask(notify))
 
@@ -297,15 +297,15 @@ async def add_team_representative(request: Request, body: MakeCaptainRequestData
         user_id = await handle(GetUserIdFromPlayerIdCommand(body.player_id))
         if user_id is None:
             return
-        data = await handle(GetNotificationSquadDataCommand(tournament_id, body.squad_id))
+        data = await handle(GetNotificationSquadDataCommand(tournament_id, body.registration_id))
         content_args = {'squad_name': data.squad_name or data.tournament_name}
         await handle(DispatchNotificationCommand([user_id], notifications.ADD_REPRESENTATIVE, content_args, f'/tournaments/details?id={tournament_id}', notifications.SUCCESS))
 
     tournament_id = request.path_params['tournament_id']
     captain_player_id = request.state.user.player_id
-    command = CheckSquadCaptainPermissionsCommand(tournament_id, body.squad_id, captain_player_id)
+    command = CheckSquadCaptainPermissionsCommand(tournament_id, body.registration_id, captain_player_id)
     await handle(command)
-    command = AddRepresentativeCommand(tournament_id, body.squad_id, body.player_id)
+    command = AddRepresentativeCommand(tournament_id, body.registration_id, body.player_id)
     await handle(command)
     return JSONResponse({}, background=BackgroundTask(notify))
 
@@ -316,15 +316,15 @@ async def remove_team_representative(request: Request, body: MakeCaptainRequestD
         user_id = await handle(GetUserIdFromPlayerIdCommand(body.player_id))
         if user_id is None:
             return
-        data = await handle(GetNotificationSquadDataCommand(tournament_id, body.squad_id))
+        data = await handle(GetNotificationSquadDataCommand(tournament_id, body.registration_id))
         content_args = {'squad_name': data.squad_name or data.tournament_name}
         await handle(DispatchNotificationCommand([user_id], notifications.REMOVE_REPRESENTATIVE, content_args, f'/tournaments/details?id={tournament_id}', notifications.WARNING))
 
     tournament_id = request.path_params['tournament_id']
     captain_player_id = request.state.user.player_id
-    command = CheckSquadCaptainPermissionsCommand(tournament_id, body.squad_id, captain_player_id)
+    command = CheckSquadCaptainPermissionsCommand(tournament_id, body.registration_id, captain_player_id)
     await handle(command)
-    command = RemoveRepresentativeCommand(tournament_id, body.squad_id, body.player_id)
+    command = RemoveRepresentativeCommand(tournament_id, body.registration_id, body.player_id)
     await handle(command)
     return JSONResponse({}, background=BackgroundTask(notify))
 
@@ -333,9 +333,9 @@ async def remove_team_representative(request: Request, body: MakeCaptainRequestD
 async def unregister_squad(request: Request, body: UnregisterSquadRequestData) -> JSONResponse:
     tournament_id = request.path_params['tournament_id']
     captain_player_id = request.state.user.player_id
-    command = CheckSquadCaptainPermissionsCommand(tournament_id, body.squad_id, captain_player_id)
+    command = CheckSquadCaptainPermissionsCommand(tournament_id, body.registration_id, captain_player_id)
     await handle(command)
-    command = UnregisterSquadCommand(tournament_id, body.squad_id)
+    command = UnregisterSquadCommand(tournament_id, body.registration_id)
     await handle(command)
     return JSONResponse({})
 
@@ -348,18 +348,18 @@ async def force_unregister_squad(request: Request, body: UnregisterSquadRequestD
     tournament_id = request.path_params['tournament_id']
 
     try: # get data before main command
-        data = await handle(GetNotificationSquadDataCommand(tournament_id, body.squad_id))
+        data = await handle(GetNotificationSquadDataCommand(tournament_id, body.registration_id))
     except Exception:
         pass
     
-    command = UnregisterSquadCommand(tournament_id, body.squad_id)
+    command = UnregisterSquadCommand(tournament_id, body.registration_id)
     await handle(command)
     return JSONResponse({}, background=BackgroundTask(notify))
 
 async def view_squad(request: Request) -> JSONResponse:
     tournament_id = request.path_params['tournament_id']
-    squad_id = request.path_params['squad_id']
-    command = GetSquadDetailsCommand(tournament_id, squad_id)
+    registration_id = request.path_params['registration_id']
+    command = GetSquadDetailsCommand(tournament_id, registration_id)
     squad = await handle(command)
     return JSONResponse(squad)
 
@@ -397,7 +397,7 @@ async def my_registration(request: Request) -> JSONResponse:
 async def toggle_checkin(request: Request, body: TournamentCheckinRequestData) -> JSONResponse:
     tournament_id = request.path_params['tournament_id']
     player_id = request.state.user.player_id
-    command = TogglePlayerCheckinCommand(tournament_id, body.squad_id, player_id)
+    command = TogglePlayerCheckinCommand(tournament_id, body.registration_id, player_id)
     await handle(command)
     return JSONResponse({})
 
@@ -406,7 +406,7 @@ async def toggle_checkin(request: Request, body: TournamentCheckinRequestData) -
 async def add_roster_to_squad(request: Request, body: AddRemoveRosterRequestData) -> JSONResponse:
     tournament_id = request.path_params['tournament_id']
     player_id = request.state.user.player_id
-    command = AddRosterToSquadCommand(tournament_id, body.squad_id, body.roster_id, player_id)
+    command = AddRosterToSquadCommand(tournament_id, body.registration_id, body.roster_id, player_id)
     await handle(command)
     return JSONResponse({})
 
@@ -415,7 +415,7 @@ async def add_roster_to_squad(request: Request, body: AddRemoveRosterRequestData
 async def remove_roster_from_squad(request: Request, body: AddRemoveRosterRequestData) -> JSONResponse:
     tournament_id = request.path_params['tournament_id']
     player_id = request.state.user.player_id
-    command = RemoveRosterFromSquadCommand(tournament_id, body.squad_id, body.roster_id, player_id)
+    command = RemoveRosterFromSquadCommand(tournament_id, body.registration_id, body.roster_id, player_id)
     await handle(command)
     return JSONResponse({})
 
@@ -423,7 +423,7 @@ async def remove_roster_from_squad(request: Request, body: AddRemoveRosterReques
 @require_tournament_permission(tournament_permissions.MANAGE_TOURNAMENT_REGISTRATIONS)
 async def force_add_roster_to_squad(request: Request, body: AddRemoveRosterRequestData) -> JSONResponse:
     tournament_id = request.path_params['tournament_id']
-    command = AddRosterToSquadCommand(tournament_id, body.squad_id, body.roster_id, None, True)
+    command = AddRosterToSquadCommand(tournament_id, body.registration_id, body.roster_id, None, True)
     await handle(command)
     return JSONResponse({})
 
@@ -431,7 +431,7 @@ async def force_add_roster_to_squad(request: Request, body: AddRemoveRosterReque
 @require_tournament_permission(tournament_permissions.MANAGE_TOURNAMENT_REGISTRATIONS)
 async def force_remove_roster_from_squad(request: Request, body: AddRemoveRosterRequestData) -> JSONResponse:
     tournament_id = request.path_params['tournament_id']
-    command = RemoveRosterFromSquadCommand(tournament_id, body.squad_id, body.roster_id, None, True)
+    command = RemoveRosterFromSquadCommand(tournament_id, body.registration_id, body.roster_id, None, True)
     await handle(command)
     return JSONResponse({})
 
@@ -457,7 +457,7 @@ routes = [
     Route('/api/tournaments/{tournament_id:int}/removeRepresentative', remove_team_representative, methods=['POST']), # dispatches notification
     Route('/api/tournaments/{tournament_id:int}/unregisterSquad', unregister_squad, methods=['POST']),
     Route('/api/tournaments/{tournament_id:int}/forceUnregisterSquad', force_unregister_squad, methods=['POST']), # dispatches notification
-    Route('/api/tournaments/{tournament_id:int}/squads/{squad_id:int}', view_squad),
+    Route('/api/tournaments/{tournament_id:int}/squads/{registration_id:int}', view_squad),
     Route('/api/tournaments/{tournament_id:int}/registrations', list_registrations),
     Route('/api/tournaments/{tournament_id:int}/myRegistration', my_registration),
     Route('/api/tournaments/{tournament_id:int}/toggleCheckin', toggle_checkin, methods=['POST']),

--- a/src/backend/api/endpoints/tournament_registration.py
+++ b/src/backend/api/endpoints/tournament_registration.py
@@ -367,13 +367,7 @@ async def view_squad(request: Request) -> JSONResponse:
 @check_tournament_visiblity
 async def list_registrations(request: Request, body: TournamentRegistrationFilter) -> JSONResponse:
     tournament_id = request.path_params['tournament_id']
-    command = CheckIfSquadTournament(tournament_id)
-    is_squad = await handle(command)
-    if is_squad:
-        print(body.is_approved)
-        command = GetSquadRegistrationsCommand(tournament_id, body.registered_only, body.eligible_only, body.hosts_only, body.is_approved)
-    else:
-        command = GetFFARegistrationsCommand(tournament_id, body.eligible_only, body.hosts_only, body.is_approved)
+    command = GetTournamentRegistrationsCommand(tournament_id, body.registered_only, body.eligible_only, body.hosts_only, body.is_approved)
     registrations = await handle(command)
     return JSONResponse(registrations)
 
@@ -383,12 +377,7 @@ async def my_registration(request: Request) -> JSONResponse:
     player_id = request.state.user.player_id
     if not player_id:
         return JSONResponse(None)
-    command = CheckIfSquadTournament(tournament_id)
-    is_squad = await handle(command)
-    if is_squad:
-        command = GetPlayerSquadRegCommand(tournament_id, request.state.user.player_id)
-    else:
-        command = GetPlayerSoloRegCommand(tournament_id, request.state.user.player_id)
+    command = GetPlayerRegistrationCommand(tournament_id, request.state.user.player_id)
     registrations = await handle(command)
     return JSONResponse(registrations)
 

--- a/src/backend/common/data/commands/players/players.py
+++ b/src/backend/common/data/commands/players/players.py
@@ -248,13 +248,13 @@ class ListPlayersCommand(Command[PlayerList]):
             append_equal_filter(filter.discord_id, "d.discord_id")
 
             # make sure that player is in a team roster which is linked to the passed-in squad ID
-            if filter.squad_id is not None:
+            if filter.registration_id is not None:
                 where_clauses.append(f"""p.id IN (
                                      SELECT m.player_id FROM team_members m
                                      JOIN team_squad_registrations r ON r.roster_id = m.roster_id
-                                     WHERE r.squad_id IS ? AND m.leave_date IS ?
+                                     WHERE r.registration_id IS ? AND m.leave_date IS ?
                 )""")
-                variable_parameters.append(filter.squad_id)
+                variable_parameters.append(filter.registration_id)
                 variable_parameters.append(None)
 
             # if has_connected_user is true, we should only list players who have

--- a/src/backend/common/data/commands/system/v1_migration.py
+++ b/src/backend/common/data/commands/system/v1_migration.py
@@ -657,24 +657,24 @@ class ConvertMKCV1DataCommand(Command[None]):
                 await s3_wrapper.put_object(s3.TOURNAMENTS_BUCKET, f'{tournament.id}.json', s3_message)
 
             # tournament registrations
-            await db.executemany("""INSERT INTO tournament_squads(id, name, tag, color, timestamp, tournament_id, is_registered, is_approved)
+            await db.executemany("""INSERT INTO tournament_registrations(id, name, tag, color, timestamp, tournament_id, is_registered, is_approved)
                                     VALUES(?, ?, ?, ?, ?, ?, ?, ?)""",
                                     [(s.id, s.name, s.tag, s.color, s.timestamp, s.tournament_id, s.is_registered, s.is_approved) for s in new_squads])
-            await db.executemany("""INSERT INTO tournament_players(id, player_id, tournament_id, squad_id, is_squad_captain, timestamp,
+            await db.executemany("""INSERT INTO tournament_players(id, player_id, tournament_id, registration_id, is_squad_captain, timestamp,
                                     is_checked_in, mii_name, can_host, is_invite, selected_fc_id, is_representative, is_bagger_clause,
                                     is_approved) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                                    [(p.id, p.player_id, p.tournament_id, p.squad_id, p.is_squad_captain, p.timestamp,
+                                    [(p.id, p.player_id, p.tournament_id, p.registration_id, p.is_squad_captain, p.timestamp,
                                       p.is_checked_in, p.mii_name, p.can_host, p.is_invite, p.selected_fc_id, p.is_representative,
                                       False, p.is_approved) for p in new_tournament_players])
-            await db.executemany("""INSERT INTO team_squad_registrations(roster_id, squad_id, tournament_id)
-                                    VALUES(?, ?, ?)""", [(r.roster_id, r.squad_id, r.tournament_id) for r in roster_squad_links])
+            await db.executemany("""INSERT INTO team_squad_registrations(roster_id, registration_id, tournament_id)
+                                    VALUES(?, ?, ?)""", [(r.roster_id, r.registration_id, r.tournament_id) for r in roster_squad_links])
             
             # tournament placements
             await db.executemany("""INSERT INTO tournament_solo_placements(tournament_id, player_id, placement, placement_description, placement_lower_bound, is_disqualified)
                                     VALUES(?, ?, ?, ?, ?, ?)""", [(p.tournament_id, p.player_id, p.placement, p.placement_description, p.placement_lower_bound,
                                                                    p.is_disqualified) for p in solo_placements])
-            await db.executemany("""INSERT INTO tournament_squad_placements(tournament_id, squad_id, placement, placement_description, placement_lower_bound, is_disqualified)
-                                 VALUES(?, ?, ?, ?, ?, ?)""", [(p.tournament_id, p.squad_id, p.placement, p.placement_description, p.placement_lower_bound,
+            await db.executemany("""INSERT INTO tournament_squad_placements(tournament_id, registration_id, placement, placement_description, placement_lower_bound, is_disqualified)
+                                 VALUES(?, ?, ?, ?, ?, ?)""", [(p.tournament_id, p.registration_id, p.placement, p.placement_description, p.placement_lower_bound,
                                                                    p.is_disqualified) for p in squad_placements])
 
             # tournament templates

--- a/src/backend/common/data/commands/teams/rosters.py
+++ b/src/backend/common/data/commands/teams/rosters.py
@@ -175,16 +175,16 @@ class LeaveRosterCommand(Command[None]):
             await db.execute("""INSERT INTO team_transfers(player_id, roster_id, date, roster_leave_id, is_accepted, approval_status, is_bagger_clause)
                              VALUES (?, ?, ?, ?, ?, ?, ?)""", (self.player_id, None, leave_date, self.roster_id, True, "approved", False))
             # get all team tournament rosters the player is in where the tournament hasn't ended yet
-            async with db.execute("""SELECT p.squad_id FROM tournament_players p
-                                JOIN team_squad_registrations s ON p.squad_id = s.squad_id
+            async with db.execute("""SELECT p.registration_id FROM tournament_players p
+                                JOIN team_squad_registrations s ON p.registration_id = s.registration_id
                                 JOIN tournaments t ON p.tournament_id = t.id
                                 WHERE p.player_id = ? AND s.roster_id = ?
                                 AND (t.date_end > ? OR t.registrations_open = ?) AND t.team_members_only = ?""",
                                 (self.player_id, self.roster_id, leave_date, True, True)) as cursor:
                 rows = await cursor.fetchall()
-                squad_ids: list[int] = [row[0] for row in rows]
+                registration_ids: list[int] = [row[0] for row in rows]
             # finally remove the player from all the tournaments they shouldn't be in
-            await db.execute(f"DELETE FROM tournament_players WHERE player_id = ? AND squad_id IN ({','.join(map(str, squad_ids))})", (self.player_id,))
+            await db.execute(f"DELETE FROM tournament_players WHERE player_id = ? AND registration_id IN ({','.join(map(str, registration_ids))})", (self.player_id,))
             await db.commit()
 
 @save_to_command_log
@@ -426,7 +426,7 @@ class GetRegisterableRostersCommand(Command[list[TeamRoster]]):
                         AND tr.id NOT IN (
                             SELECT roster_id
                             FROM team_squad_registrations tsr
-                            JOIN tournament_squads s ON tsr.squad_id = s.id
+                            JOIN tournament_registrations s ON tsr.registration_id = s.id
                             WHERE tsr.tournament_id = ?
                             AND s.is_registered = ?
                         )"""

--- a/src/backend/common/data/commands/teams/transfers.py
+++ b/src/backend/common/data/commands/teams/transfers.py
@@ -33,19 +33,19 @@ class ApproveTransferCommand(Command[None]):
             if team_member_id:
                 await db.execute("UPDATE team_members SET leave_date = ? WHERE id = ?", (curr_time, team_member_id))
                 # get all team tournament rosters the player is in where the tournament hasn't ended yet
-                async with db.execute("""SELECT p.squad_id FROM tournament_players p
-                                    JOIN team_squad_registrations s ON p.squad_id = s.squad_id
+                async with db.execute("""SELECT p.registration_id FROM tournament_players p
+                                    JOIN team_squad_registrations s ON p.registration_id = s.registration_id
                                     JOIN tournaments t ON p.tournament_id = t.id
                                     WHERE p.player_id = ? AND s.roster_id = ?
                                     AND (t.date_end > ? OR t.registrations_open = ?) AND t.team_members_only = ?
                                     AND p.is_bagger_clause = ?""",
                                     (player_id, roster_leave_id, curr_time, True, True, is_bagger_clause)) as cursor:
                     rows = await cursor.fetchall()
-                    squad_ids: list[int] = [row[0] for row in rows]
+                    registration_ids: list[int] = [row[0] for row in rows]
                 # if any of these squads the player was in previously are also linked to the new roster,
                 # (such as when transferring between two rosters of same team), we don't want to remove them
-                async with db.execute("""SELECT p.squad_id FROM tournament_players p
-                                    JOIN team_squad_registrations s ON p.squad_id = s.squad_id
+                async with db.execute("""SELECT p.registration_id FROM tournament_players p
+                                    JOIN team_squad_registrations s ON p.registration_id = s.registration_id
                                     JOIN tournaments t ON p.tournament_id = t.id
                                     WHERE p.player_id = ? AND s.roster_id = ?
                                     AND (t.date_end > ? OR t.registrations_open = ?) AND t.team_members_only = ?
@@ -53,18 +53,18 @@ class ApproveTransferCommand(Command[None]):
                                     (player_id, roster_id, curr_time, True, True, is_bagger_clause)) as cursor:
                     rows = await cursor.fetchall()
                     for row in rows:
-                        if row[0] in squad_ids:
-                            squad_ids.remove(row[0])
+                        if row[0] in registration_ids:
+                            registration_ids.remove(row[0])
                 # finally remove the player from all the tournaments they shouldn't be in
-                await db.execute(f"DELETE FROM tournament_players WHERE player_id = ? AND squad_id IN ({','.join(map(str, squad_ids))})", (player_id,))
+                await db.execute(f"DELETE FROM tournament_players WHERE player_id = ? AND registration_id IN ({','.join(map(str, registration_ids))})", (player_id,))
 
             # next we want to automatically add the transferred player to any team tournaments where that team is registered
             # and registrations are open
-            async with db.execute("""SELECT s.squad_id, t.id FROM team_squad_registrations s
+            async with db.execute("""SELECT s.registration_id, t.id FROM team_squad_registrations s
                                     JOIN tournaments t ON s.tournament_id = t.id
                                     WHERE t.teams_allowed = ? AND t.registrations_open = ?
                                     AND s.roster_id = ? AND NOT EXISTS (
-                                        SELECT p.id FROM tournament_players p WHERE p.player_id = ? AND p.squad_id = s.squad_id
+                                        SELECT p.id FROM tournament_players p WHERE p.player_id = ? AND p.registration_id = s.registration_id
                                   )""", (True, True, roster_id, player_id)) as cursor:
                 rows = await cursor.fetchall()
                 squads: dict[int, int] = {}
@@ -73,16 +73,16 @@ class ApproveTransferCommand(Command[None]):
                     squads[tournament] = squad
             # if the player is already in some of these tournaments we don't want to add them again
             tournament_query = ','.join(map(str, squads.keys()))
-            async with db.execute(f"SELECT squad_id, tournament_id FROM tournament_players WHERE player_id = ? AND is_bagger_clause = ? AND tournament_id IN ({tournament_query})",
+            async with db.execute(f"SELECT registration_id, tournament_id FROM tournament_players WHERE player_id = ? AND is_bagger_clause = ? AND tournament_id IN ({tournament_query})",
                                   (player_id, is_bagger_clause)) as cursor:
                 rows = await cursor.fetchall()
                 for row in rows:
                     squad, tournament = row
                     if tournament in squads.keys():
                         del squads[tournament]
-            insert_rows = [(player_id, tournament_id, squad_id, False, curr_time, False, None, False, False, None, False, is_bagger_clause,
-                            False) for tournament_id, squad_id in squads.items()]
-            await db.executemany("""INSERT INTO tournament_players(player_id, tournament_id, squad_id, is_squad_captain, timestamp, is_checked_in, mii_name, can_host, is_invite, selected_fc_id, 
+            insert_rows = [(player_id, tournament_id, registration_id, False, curr_time, False, None, False, False, None, False, is_bagger_clause,
+                            False) for tournament_id, registration_id in squads.items()]
+            await db.executemany("""INSERT INTO tournament_players(player_id, tournament_id, registration_id, is_squad_captain, timestamp, is_checked_in, mii_name, can_host, is_invite, selected_fc_id, 
                                  is_representative, is_bagger_clause, is_approved)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""", insert_rows)
             await db.commit()
@@ -268,19 +268,19 @@ class ForceTransferPlayerCommand(Command[None]):
             if team_member_id:
                 await db.execute("UPDATE team_members SET leave_date = ? WHERE id = ?", (curr_time, team_member_id))
                 # get all team tournament rosters the player is in where the tournament hasn't ended yet
-                async with db.execute("""SELECT p.squad_id FROM tournament_players p
-                                    JOIN team_squad_registrations s ON p.squad_id = s.squad_id
+                async with db.execute("""SELECT p.registration_id FROM tournament_players p
+                                    JOIN team_squad_registrations s ON p.registration_id = s.registration_id
                                     JOIN tournaments t ON p.tournament_id = t.id
                                     WHERE p.player_id = ? AND s.roster_id = ?
                                     AND (t.date_end > ? OR t.registrations_open = ?) AND t.team_members_only = ?
                                     AND p.is_bagger_clause = ?""",
                                     (self.player_id, self.roster_leave_id, curr_time, True, True, self.is_bagger_clause)) as cursor:
                     rows = await cursor.fetchall()
-                    squad_ids: list[int] = [row[0] for row in rows]
+                    registration_ids: list[int] = [row[0] for row in rows]
                 # if any of these squads the player was in previously are also linked to the new roster,
                 # (such as when transferring between two rosters of same team), we don't want to remove them
-                async with db.execute("""SELECT p.squad_id FROM tournament_players p
-                                    JOIN team_squad_registrations s ON p.squad_id = s.squad_id
+                async with db.execute("""SELECT p.registration_id FROM tournament_players p
+                                    JOIN team_squad_registrations s ON p.registration_id = s.registration_id
                                     JOIN tournaments t ON p.tournament_id = t.id
                                     WHERE p.player_id = ? AND s.roster_id = ?
                                     AND (t.date_end > ? OR t.registrations_open = ?) AND t.team_members_only = ?
@@ -288,19 +288,19 @@ class ForceTransferPlayerCommand(Command[None]):
                                     (self.player_id, self.roster_id, curr_time, True, True, self.is_bagger_clause)) as cursor:
                     rows = await cursor.fetchall()
                     for row in rows:
-                        if row[0] in squad_ids:
-                            squad_ids.remove(row[0])
+                        if row[0] in registration_ids:
+                            registration_ids.remove(row[0])
                 # finally remove the player from all the tournaments they shouldn't be in
-                await db.execute(f"DELETE FROM tournament_players WHERE player_id = ? AND squad_id IN ({','.join(map(str, squad_ids))})", (self.player_id,))
+                await db.execute(f"DELETE FROM tournament_players WHERE player_id = ? AND registration_id IN ({','.join(map(str, registration_ids))})", (self.player_id,))
 
             # next we want to automatically add the transferred player to any team tournaments where that team is registered
             # and registrations are open
-            async with db.execute("""SELECT s.squad_id, t.id FROM team_squad_registrations s
+            async with db.execute("""SELECT s.registration_id, t.id FROM team_squad_registrations s
                                     JOIN tournaments t ON s.tournament_id = t.id
                                     WHERE t.teams_allowed = ? AND t.registrations_open = ?
                                     AND s.roster_id = ? AND NOT EXISTS (
                                         SELECT p.id FROM tournament_players p 
-                                        WHERE p.player_id = ? AND p.squad_id = s.squad_id
+                                        WHERE p.player_id = ? AND p.registration_id = s.registration_id
                                     )""", (True, True, self.roster_id, self.player_id)) as cursor:
                 rows = await cursor.fetchall()
                 squads: dict[int, int] = {}
@@ -309,16 +309,16 @@ class ForceTransferPlayerCommand(Command[None]):
                     squads[tournament] = squad
             # if the player is already in some of these tournaments we don't want to add them again
             tournament_query = ','.join(map(str, squads.keys()))
-            async with db.execute(f"SELECT squad_id, tournament_id FROM tournament_players WHERE player_id = ? AND tournament_id IN ({tournament_query})",
+            async with db.execute(f"SELECT registration_id, tournament_id FROM tournament_players WHERE player_id = ? AND tournament_id IN ({tournament_query})",
                                   (self.player_id,)) as cursor:
                 rows = await cursor.fetchall()
                 for row in rows:
                     squad, tournament = row
                     if tournament in squads.keys():
                         del squads[tournament]
-            insert_rows = [(self.player_id, tournament_id, squad_id, False, curr_time, False, None, False, False, None, False, self.is_bagger_clause,
-                            False) for tournament_id, squad_id in squads.items()]
-            await db.executemany("""INSERT INTO tournament_players(player_id, tournament_id, squad_id, is_squad_captain, timestamp, is_checked_in, mii_name, can_host, is_invite, selected_fc_id, 
+            insert_rows = [(self.player_id, tournament_id, registration_id, False, curr_time, False, None, False, False, None, False, self.is_bagger_clause,
+                            False) for tournament_id, registration_id in squads.items()]
+            await db.executemany("""INSERT INTO tournament_players(player_id, tournament_id, registration_id, is_squad_captain, timestamp, is_checked_in, mii_name, can_host, is_invite, selected_fc_id, 
                                  is_representative, is_bagger_clause, is_approved)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""", insert_rows)
             await db.commit()

--- a/src/backend/common/data/commands/tournaments/placements.py
+++ b/src/backend/common/data/commands/tournaments/placements.py
@@ -6,74 +6,11 @@ from datetime import datetime, timezone
 
 @save_to_command_log
 @dataclass
-class SetSoloPlacementsCommand(Command[None]):
-    tournament_id: int
-    body: list[TournamentPlacement]
-    registrations: list[TournamentPlayerDetails]
-
-    async def handle(self, db_wrapper, s3_wrapper):
-        b = self.body
-        # for solo placements, we use the player ID since tournament registration ID is not visible to the frontend
-        registration_dict = {r.player_id: r for r in self.registrations}
-        # sort with DQs at the end
-        sorted_placements = sorted(b, key=lambda x: float('inf') if x.placement is None else x.placement)
-
-        # going through placements in order of rank to make sure they fulfill all criteria
-        curr_placement = 1
-        curr_bound = None
-        for i, placement in enumerate(sorted_placements):
-            if placement.placement_description and len(placement.placement_description) > 32:
-                raise Problem("Placement descriptions must be 32 characters or less", status=400)
-            if placement.placement is None:
-                if not placement.is_disqualified:
-                    raise Problem("Cannot have null placement value when not disqualified", status=400)
-                if placement.placement_lower_bound:
-                    raise Problem("Placement must be non-null to set lower bound", status=400)
-                if placement.placement_description:
-                    raise Problem("Cannot have description for null placements", status=400)
-            if placement.placement and placement.is_disqualified:
-                raise Problem("Cannot have a placement value while disqualified", status=400)
-            if placement.registration_id not in registration_dict.keys():
-                raise Problem(f"Registration ID {placement.registration_id} not found in tournament", status=400)
-            # if the current placement is not equal to its sorted position in the list or is not tied with the previous placement
-            if placement.placement is not None and placement.placement != i+1 and placement.placement != curr_placement:
-                raise Problem(f"Error processing placements: Placement for ID {placement.registration_id} has value {placement.placement} instead of {i+1} or {curr_placement}", status=400)
-            if i > 0 and placement.placement == curr_placement and placement.placement_lower_bound != curr_bound:
-                raise Problem(f"""All entries with the same placement must have the same lower bound as well (two placements found with bounds {curr_placement}-{curr_bound} 
-                              and {placement.placement}-{placement.placement_lower_bound})""", status=400)
-            # example: we should have exactly 3 placements with placement 3 and lower bound 5, so if the placement changes early throw a error
-            if placement.placement != curr_placement and curr_bound is not None and i != curr_bound:
-                raise Problem(f"""Expected {curr_bound - curr_placement + 1} placements with value {curr_placement}-{curr_bound}, but only found {i - curr_placement + 1}""",
-                              status=400)
-            
-            if placement.placement_lower_bound != curr_bound and placement.placement_lower_bound is not None:
-                if placement.placement_lower_bound <= i+1:
-                    raise Problem(f"Error in placement for ID {placement.registration_id}: Placement lower bound should always be greater than placement", status=400)
-                if placement.placement_lower_bound >= len(sorted_placements):
-                    raise Problem(f"Error in placement for ID {placement.registration_id}: Placement lower bound should not be higher than total num of placements", status=400)
-
-            if placement.placement != curr_placement:
-                curr_placement = i+1
-            if placement.placement_lower_bound != curr_bound:
-                curr_bound = placement.placement_lower_bound
-
-        async with db_wrapper.connect() as db:
-            params = [(self.tournament_id, registration_dict[p.registration_id].id, p.placement, 
-                        p.placement_description, p.placement_lower_bound, p.is_disqualified) for p in b]
-            await db.execute("DELETE FROM tournament_solo_placements WHERE tournament_id = ?", (self.tournament_id,))
-            await db.executemany("""INSERT INTO tournament_solo_placements(
-                                    tournament_id, player_id, placement, placement_description, placement_lower_bound, is_disqualified
-                                    ) VALUES (?, ?, ?, ?, ?, ?)""", params)
-            await db.commit()
-
-@save_to_command_log
-@dataclass
-class SetSquadPlacementsCommand(Command[None]):
+class SetTournamentPlacementsCommand(Command[None]):
     tournament_id: int
     body: list[TournamentPlacement]
     registrations: list[TournamentSquadDetails]
     
-
     async def handle(self, db_wrapper, s3_wrapper):
         b = self.body
         registration_dict = {reg.id: reg for reg in self.registrations}
@@ -121,15 +58,15 @@ class SetSquadPlacementsCommand(Command[None]):
             
         async with db_wrapper.connect() as db:
             params = [(self.tournament_id, p.registration_id, p.placement, p.placement_description, p.placement_lower_bound, p.is_disqualified) for p in b]
-            await db.execute("DELETE FROM tournament_squad_placements WHERE tournament_id = ?", (self.tournament_id,))
-            await db.executemany("""INSERT INTO tournament_squad_placements(
+            await db.execute("DELETE FROM tournament_placements WHERE tournament_id = ?", (self.tournament_id,))
+            await db.executemany("""INSERT INTO tournament_placements(
                                     tournament_id, registration_id, placement, placement_description, placement_lower_bound, is_disqualified
                                     ) VALUES (?, ?, ?, ?, ?, ?)""", params)
             await db.commit()
 
 @save_to_command_log
 @dataclass
-class SetSquadPlacementsFromPlayerIDsCommand(Command[None]):
+class SetTournamentPlacementsFromPlayerIDsCommand(Command[None]):
     tournament_id: int
     body: list[TournamentPlacementFromPlayerIDs]
 
@@ -138,13 +75,11 @@ class SetSquadPlacementsFromPlayerIDsCommand(Command[None]):
         # sort with DQs at the end
         sorted_placements = sorted(b, key=lambda x: float('inf') if x.placement is None else x.placement)
         async with db_wrapper.connect() as db:
-            async with db.execute("SELECT is_squad, min_squad_size, max_squad_size FROM tournaments WHERE id = ?", (self.tournament_id,)) as cursor:
+            async with db.execute("SELECT min_squad_size, max_squad_size FROM tournaments WHERE id = ?", (self.tournament_id,)) as cursor:
                 row = await cursor.fetchone()
                 if not row:
                     raise Problem("Tournament not found", status=404)
-                is_squad, min_squad_size, max_squad_size = row
-                if not bool(is_squad):
-                    raise Problem("This endpoint can only be used for squad tournaments", status=400)
+                min_squad_size, max_squad_size = row
 
         # going through placements in order of rank to make sure they fulfill all criteria
         curr_placement = 1
@@ -159,9 +94,9 @@ class SetSquadPlacementsFromPlayerIDsCommand(Command[None]):
                     raise Problem("Placement must be non-null to set lower bound", status=400)
                 if placement.placement_description:
                     raise Problem("Cannot have description for null placements", status=400)
-            if len(placement.player_ids) < min_squad_size:
+            if min_squad_size is not None and len(placement.player_ids) < min_squad_size:
                 raise Problem(f"Error in placement for ID {placement.player_ids}: Row has less players than minimum squad size")
-            if len(placement.player_ids) > max_squad_size:
+            if max_squad_size is not None and len(placement.player_ids) > max_squad_size:
                 raise Problem(f"Error in placement for ID {placement.player_ids}: Row has more players than maximum squad size")
             if placement.placement and placement.is_disqualified:
                 raise Problem("Cannot have a placement value while disqualified", status=400)
@@ -190,7 +125,7 @@ class SetSquadPlacementsFromPlayerIDsCommand(Command[None]):
         squad_dict: dict[int, TournamentPlacementFromPlayerIDs] = {}
         now = int(datetime.now(timezone.utc).timestamp())
         async with db_wrapper.connect() as db:
-            await db.execute("DELETE FROM tournament_squad_placements WHERE tournament_id = ?", (self.tournament_id,))
+            await db.execute("DELETE FROM tournament_placements WHERE tournament_id = ?", (self.tournament_id,))
             await db.execute("DELETE FROM tournament_players WHERE tournament_id = ?", (self.tournament_id,))
             await db.execute("DELETE FROM tournament_registrations WHERE tournament_id = ?", (self.tournament_id,))
             for placement in sorted_placements:
@@ -207,35 +142,19 @@ class SetSquadPlacementsFromPlayerIDsCommand(Command[None]):
                                     VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""", player_rows)
             placement_rows = [(self.tournament_id, registration_id, placement.placement, placement.placement_description,
                                placement.placement_lower_bound, placement.is_disqualified) for registration_id, placement in squad_dict.items()]
-            await db.executemany("""INSERT INTO tournament_squad_placements(tournament_id, registration_id, placement, placement_description, 
+            await db.executemany("""INSERT INTO tournament_placements(tournament_id, registration_id, placement, placement_description, 
                                  placement_lower_bound, is_disqualified) VALUES(?, ?, ?, ?, ?, ?)""", placement_rows)
             await db.commit()
 
 @dataclass
-class GetSoloPlacementsCommand(Command[TournamentPlacementList]):
-    tournament_id: int
-    players: list[TournamentPlayerDetails]
-
-    async def handle(self, db_wrapper, s3_wrapper):
-        player_dict = {player.id: player for player in self.players}
-        async with db_wrapper.connect(readonly=True) as db:
-            async with db.execute("""SELECT player_id, placement, placement_description, placement_lower_bound, is_disqualified FROM tournament_solo_placements WHERE tournament_id = ? ORDER BY placement""", (self.tournament_id,)) as cursor:
-                rows = await cursor.fetchall()
-                placed_players = [TournamentPlacementDetailed(reg_id, placement, placement_description, placement_lower_bound, is_dq, player_dict[reg_id], None) 
-                                  for reg_id, placement, placement_description, placement_lower_bound, is_dq in rows]
-                placed_ids = [p.registration_id for p in placed_players]
-                unplaced_players = [TournamentPlacementDetailed(player.id, None, None, None, False, player, None) for player in self.players if player.id not in placed_ids]
-                return TournamentPlacementList(self.tournament_id, False, placed_players, unplaced_players)
-
-@dataclass
-class GetSquadPlacementsCommand(Command[TournamentPlacementList]):
+class GetTournamentPlacementsCommand(Command[TournamentPlacementList]):
     tournament_id: int
     squads: list[TournamentSquadDetails]
 
     async def handle(self, db_wrapper, s3_wrapper):
         squad_dict = {squad.id: squad for squad in self.squads}
         async with db_wrapper.connect(readonly=True) as db:
-            async with db.execute("SELECT registration_id, placement, placement_description, placement_lower_bound, is_disqualified FROM tournament_squad_placements WHERE tournament_id = ? ORDER BY placement", (self.tournament_id,)) as cursor:
+            async with db.execute("SELECT registration_id, placement, placement_description, placement_lower_bound, is_disqualified FROM tournament_placements WHERE tournament_id = ? ORDER BY placement", (self.tournament_id,)) as cursor:
                 rows = await cursor.fetchall()
                 placed_squads: list[TournamentPlacementDetailed] = []
                 for row in rows:
@@ -243,11 +162,10 @@ class GetSquadPlacementsCommand(Command[TournamentPlacementList]):
                     squad = squad_dict.get(reg_id, None)
                     if not squad:
                         continue
-                    placed_squads.append(TournamentPlacementDetailed(reg_id, placement, placement_description, placement_lower_bound, is_dq, None, squad))
+                    placed_squads.append(TournamentPlacementDetailed(reg_id, placement, placement_description, placement_lower_bound, is_dq, squad))
                 placed_ids = [p.registration_id for p in placed_squads]
-                unplaced_squads = [TournamentPlacementDetailed(squad.id, None, None, None, False, None, squad) for squad in self.squads if squad.id not in placed_ids]
-                return TournamentPlacementList(self.tournament_id, True, placed_squads, unplaced_squads)
-
+                unplaced_squads = [TournamentPlacementDetailed(squad.id, None, None, None, False, squad) for squad in self.squads if squad.id not in placed_ids]
+                return TournamentPlacementList(self.tournament_id, placed_squads, unplaced_squads)
 
 @dataclass
 class GetPlayerTournamentPlacementsCommand(Command[PlayerTournamentResults]):
@@ -261,25 +179,7 @@ class GetPlayerTournamentPlacementsCommand(Command[PlayerTournamentResults]):
         tournament_solo_and_squad_results: list[PlayerTournamentPlacement] = []
         tournament_team_results: list[PlayerTournamentPlacement] = []
         async with db_wrapper.connect(readonly=True) as db:
-            # Solo placements
-            async with db.execute("""
-                SELECT t.id as "tournament_id", t.name as "tournament_name", t.game, t.mode, t.date_start, t.date_end, tsp.placement, tsp.placement_description, tsp.is_disqualified
-                FROM tournament_players as tp 
-                INNER JOIN tournaments as t
-                ON tp.tournament_id = t.id 
-                LEFT JOIN tournament_solo_placements as tsp 
-                ON tp.id = tsp.player_id
-                WHERE t.show_on_profiles = 1
-                AND tp.registration_id IS NULL
-                AND t.teams_only = 0
-                AND tp.player_id = ?
-                """, (self.player_id,)) as cursor:
-                rows = await cursor.fetchall()
-                for row in rows:
-                    tournament_id, tournament_name, game, mode, date_start, date_end, placement, placement_description, is_disqualified = row
-                    tournament_solo_and_squad_results.append(PlayerTournamentPlacement(tournament_id, tournament_name, game, mode, None, None, None, date_start, date_end, placement, placement_description, is_disqualified, []))
-
-            # Squad placements (squad tournaments with squad size 1-4)
+            # Solo + Squad placements (squad tournaments with squad size 1-4)
             squad_dict: dict[int, PlayerTournamentPlacement] = {}
             async with db.execute("""
                 SELECT t.id as "tournament_id", t.name as "tournament_name", t.game, t.mode, s.id, s.name, t.date_start, t.date_end, tsp.placement, tsp.placement_description, tsp.is_disqualified
@@ -287,12 +187,12 @@ class GetPlayerTournamentPlacementsCommand(Command[PlayerTournamentResults]):
                 INNER JOIN tournaments as t
                 ON tp.tournament_id = t.id
                 JOIN tournament_registrations s ON s.id = tp.registration_id
-                LEFT JOIN tournament_squad_placements as tsp 
+                LEFT JOIN tournament_placements as tsp 
                 ON s.id = tsp.registration_id
                 WHERE t.show_on_profiles = 1
                 AND tp.registration_id IS NOT NULL
                 AND t.teams_allowed = 0
-                AND t.min_squad_size <= 4
+                AND (t.min_squad_size IS NULL OR t.min_squad_size <= 4)
                 AND tp.player_id = ?
                 AND s.is_registered = 1
                 """, (self.player_id,)) as cursor:
@@ -307,7 +207,7 @@ class GetPlayerTournamentPlacementsCommand(Command[PlayerTournamentResults]):
             async with db.execute("""
                 SELECT tp.player_id, p.name, tp.registration_id
                 FROM tournament_players as tp
-                INNER JOIN tournament_squad_placements as tsp
+                INNER JOIN tournament_placements as tsp
                 ON tp.registration_id = tsp.registration_id
                 INNER JOIN tournament_registrations as ts
                 ON tsp.registration_id = ts.id
@@ -332,7 +232,7 @@ class GetPlayerTournamentPlacementsCommand(Command[PlayerTournamentResults]):
                 INNER JOIN tournaments as t
                 ON tp.tournament_id = t.id 
                 JOIN tournament_registrations s ON s.id = tp.registration_id
-                LEFT JOIN tournament_squad_placements as tsp 
+                LEFT JOIN tournament_placements as tsp 
                 ON tp.registration_id = tsp.registration_id
                 LEFT JOIN team_squad_registrations as tsr
                 ON s.id = tsr.registration_id
@@ -360,7 +260,6 @@ class GetPlayerTournamentPlacementsCommand(Command[PlayerTournamentResults]):
                 results = PlayerTournamentResults(tournament_solo_and_squad_results, tournament_team_results)
                 return results
 
-
 @dataclass
 class GetTeamTournamentPlacementsCommand(Command[TeamTournamentResults]):
     """
@@ -378,7 +277,7 @@ class GetTeamTournamentPlacementsCommand(Command[TeamTournamentResults]):
                 JOIN tournament_registrations s ON s.tournament_id = t.id
                 INNER JOIN team_squad_registrations as tsr
                 ON tsr.registration_id = s.id
-                LEFT JOIN tournament_squad_placements as tsp 
+                LEFT JOIN tournament_placements as tsp 
                 ON tsr.registration_id = tsp.registration_id
                 INNER JOIN team_rosters as tr ON
                 tsr.roster_id = tr.id
@@ -402,10 +301,7 @@ class GetLatestTournamentIdWithPlacements(Command[int]):
         async with db_wrapper.connect(readonly=True) as db:
             async with db.execute("""
                 SELECT MAX(id) FROM tournaments where is_viewable = 1 AND is_public = 1 AND id IN (
-                    SELECT tournament_id from (
-                        SELECT tournament_id FROM tournament_squad_placements UNION 
-                        SELECT tournament_id FROM tournament_solo_placements
-                    )
+                    SELECT tournament_id from tournament_placements
                 )
                 """) as cursor:
                 row = await cursor.fetchone()

--- a/src/backend/common/data/commands/tournaments/registrations.py
+++ b/src/backend/common/data/commands/tournaments/registrations.py
@@ -10,7 +10,7 @@ from common.data.models import *
 class RegisterPlayerCommand(Command[None]):
     player_id: int
     tournament_id: int
-    squad_id: int | None
+    registration_id: int | None
     is_squad_captain: bool
     is_checked_in: bool
     mii_name: str | None
@@ -32,9 +32,9 @@ class RegisterPlayerCommand(Command[None]):
                 if row is None:
                     raise Problem("Tournament not found", status=404)
                 is_squad, max_squad_size, mii_name_required, registrations_open, team_members_only, require_single_fc, bagger_clause_enabled = row
-                if bool(is_squad) and self.squad_id is None:
+                if bool(is_squad) and self.registration_id is None:
                     raise Problem("Players may not register alone for squad tournaments", status=400)
-                if not bool(is_squad) and self.squad_id is not None:
+                if not bool(is_squad) and self.registration_id is not None:
                     raise Problem("Players may not register for a squad for solo tournaments", status=400)
                 if (not registrations_open) and (not self.is_privileged):
                     raise Problem("Tournament registrations are closed", status=400)
@@ -61,8 +61,8 @@ class RegisterPlayerCommand(Command[None]):
                         raise Problem("Player not found", status=404)
             
             # check if squad exists and if we are using the squad's tag in our mii name
-            if self.squad_id is not None:
-                async with db.execute("SELECT tag FROM tournament_squads WHERE id = ? AND tournament_id = ?", (self.squad_id, self.tournament_id)) as cursor:
+            if self.registration_id is not None:
+                async with db.execute("SELECT tag FROM tournament_registrations WHERE id = ? AND tournament_id = ?", (self.registration_id, self.tournament_id)) as cursor:
                     row = await cursor.fetchone()
                     if row is None:
                         raise Problem("Squad not found", status=404)
@@ -75,22 +75,22 @@ class RegisterPlayerCommand(Command[None]):
             if bool(team_members_only):
                 async with db.execute("""SELECT m.id FROM team_members m
                     JOIN team_squad_registrations r ON m.roster_id = r.roster_id
-                    WHERE m.player_id = ? AND m.leave_date IS ? AND r.squad_id IS ?""",
-                    (self.player_id, None, self.squad_id)) as cursor:
+                    WHERE m.player_id = ? AND m.leave_date IS ? AND r.registration_id IS ?""",
+                    (self.player_id, None, self.registration_id)) as cursor:
                     row = await cursor.fetchone()
                     if row is None:
                         raise Problem("Player must be registered for a team roster linked to this squad", status=400)
                     
             # check if player has already registered for the tournament
-            async with db.execute("SELECT squad_id, is_bagger_clause from tournament_players WHERE player_id = ? AND tournament_id = ? AND is_invite = 0", 
+            async with db.execute("SELECT registration_id, is_bagger_clause from tournament_players WHERE player_id = ? AND tournament_id = ? AND is_invite = 0", 
                                   (self.player_id, self.tournament_id)) as cursor:
                 rows = await cursor.fetchall()
                 for row in rows:
-                    existing_squad_id, is_bagger_clause = row
-                    # if row exists but existing_squad_id is None, it's a FFA and theyre already registered
-                    if not existing_squad_id:
+                    existing_registration_id, is_bagger_clause = row
+                    # if row exists but existing_registration_id is None, it's a FFA and theyre already registered
+                    if not existing_registration_id:
                         raise Problem("Player is already registered for this tournament", status=400)
-                    if existing_squad_id == self.squad_id:
+                    if existing_registration_id == self.registration_id:
                         raise Problem("Player is already invited to/registered for this squad", status=400)
                     # should still be able to invite someone if they are registered for the tournament
                     # if the registered player's bagger clause is the opposite of our current one, let them register
@@ -98,15 +98,15 @@ class RegisterPlayerCommand(Command[None]):
                         raise Problem('Player is already registered for this tournament', status=400)
                     
             # check if player's squad is at maximum number of players
-            if self.squad_id is not None and max_squad_size is not None:
-                async with db.execute("SELECT id FROM tournament_players WHERE tournament_id = ? AND squad_id IS ?", (self.tournament_id, self.squad_id)) as cursor:
+            if self.registration_id is not None and max_squad_size is not None:
+                async with db.execute("SELECT id FROM tournament_players WHERE tournament_id = ? AND registration_id IS ?", (self.tournament_id, self.registration_id)) as cursor:
                     player_squad_size = cursor.rowcount
                     if player_squad_size >= max_squad_size:
                         raise Problem('Squad at maximum number of players', status=400)
                     
-            await db.execute("""INSERT INTO tournament_players(player_id, tournament_id, squad_id, is_squad_captain, timestamp, is_checked_in, mii_name, can_host, is_invite, selected_fc_id, 
+            await db.execute("""INSERT INTO tournament_players(player_id, tournament_id, registration_id, is_squad_captain, timestamp, is_checked_in, mii_name, can_host, is_invite, selected_fc_id, 
                              is_representative, is_bagger_clause, is_approved)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""", (self.player_id, self.tournament_id, self.squad_id, self.is_squad_captain, timestamp, self.is_checked_in, self.mii_name, self.can_host, 
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""", (self.player_id, self.tournament_id, self.registration_id, self.is_squad_captain, timestamp, self.is_checked_in, self.mii_name, self.can_host, 
                 self.is_invite, selected_fc_id, self.is_representative, self.is_bagger_clause, self.is_approved))
             await db.commit()
 
@@ -115,7 +115,7 @@ class RegisterPlayerCommand(Command[None]):
 @dataclass
 class EditPlayerRegistrationCommand(Command[None]):
     tournament_id: int
-    squad_id: int | None
+    registration_id: int | None
     player_id: int
     mii_name: str | None
     can_host: bool
@@ -153,8 +153,8 @@ class EditPlayerRegistrationCommand(Command[None]):
                     raise Problem("Cannot register as bagger when bagger clause is not enabled", status=400)
                     
             #check if registration exists
-            async with db.execute("SELECT id, is_invite, is_representative, is_squad_captain, is_checked_in, is_bagger_clause, is_approved FROM tournament_players WHERE tournament_id = ? AND squad_id IS ? AND player_id = ?",
-                (self.tournament_id, self.squad_id, self.player_id)) as cursor:
+            async with db.execute("SELECT id, is_invite, is_representative, is_squad_captain, is_checked_in, is_bagger_clause, is_approved FROM tournament_players WHERE tournament_id = ? AND registration_id IS ? AND player_id = ?",
+                (self.tournament_id, self.registration_id, self.player_id)) as cursor:
                 row = await cursor.fetchone()
                 if not row:
                     raise Problem("Registration not found", status=404)
@@ -178,8 +178,8 @@ class EditPlayerRegistrationCommand(Command[None]):
                 is_approved = curr_approved
 
             # check if squad exists and if we are using the squad's tag in our mii name
-            if self.squad_id is not None:
-                async with db.execute("SELECT tag FROM tournament_squads WHERE id = ? AND tournament_id = ?", (self.squad_id, self.tournament_id)) as cursor:
+            if self.registration_id is not None:
+                async with db.execute("SELECT tag FROM tournament_registrations WHERE id = ? AND tournament_id = ?", (self.registration_id, self.tournament_id)) as cursor:
                     row = await cursor.fetchone()
                     if row is None:
                         raise Problem("Squad not found", status=404)
@@ -190,17 +190,17 @@ class EditPlayerRegistrationCommand(Command[None]):
 
             # if a player accepts an invite while already registered for a different squad, their old registration must be removed
             if curr_is_invite and (not self.is_invite):
-                old_squad_id = None
+                old_registration_id = None
                 old_is_squad_captain = False
-                async with db.execute("SELECT squad_id, is_squad_captain FROM tournament_players WHERE tournament_id = ? AND player_id = ? AND is_invite = ?",
+                async with db.execute("SELECT registration_id, is_squad_captain FROM tournament_players WHERE tournament_id = ? AND player_id = ? AND is_invite = ?",
                     (self.tournament_id, self.player_id, False)) as cursor:
                     row = await cursor.fetchone()
                     if row:
-                        old_squad_id, old_is_squad_captain = row
+                        old_registration_id, old_is_squad_captain = row
                 
-                if old_squad_id:
+                if old_registration_id:
                     # we should unregister a squad if it has no members remaining after this player is unregistered
-                    async with db.execute("SELECT count(*) FROM tournament_players WHERE tournament_id = ? AND squad_id IS ? AND is_invite = 0", (self.tournament_id, old_squad_id)) as cursor:
+                    async with db.execute("SELECT count(*) FROM tournament_players WHERE tournament_id = ? AND registration_id IS ? AND is_invite = 0", (self.tournament_id, old_registration_id)) as cursor:
                         row = await cursor.fetchone()
                         assert row is not None
                         num_squad_players = row[0]
@@ -208,16 +208,16 @@ class EditPlayerRegistrationCommand(Command[None]):
                     if old_is_squad_captain and num_squad_players > 1:
                         raise Problem("Please unregister your current squad or give captain to another player in your squad before leaving your current squad", status=400)
                     if num_squad_players == 1:
-                        await db.execute("UPDATE tournament_squads SET is_registered = ? WHERE id = ?", (False, old_squad_id))
+                        await db.execute("UPDATE tournament_registrations SET is_registered = ? WHERE id = ?", (False, old_registration_id))
                         # delete any invites as well
-                        await db.execute("DELETE FROM tournament_players WHERE tournament_id = ? AND squad_id IS ? AND is_invite = 1", (self.tournament_id, old_squad_id))
-                    await db.execute("DELETE FROM tournament_players WHERE tournament_id = ? AND player_id = ? AND squad_id = ?",
-                        (self.tournament_id, self.player_id, old_squad_id))
+                        await db.execute("DELETE FROM tournament_players WHERE tournament_id = ? AND registration_id IS ? AND is_invite = 1", (self.tournament_id, old_registration_id))
+                    await db.execute("DELETE FROM tournament_players WHERE tournament_id = ? AND player_id = ? AND registration_id = ?",
+                        (self.tournament_id, self.player_id, old_registration_id))
                     
             # if we're making this player the captain, make sure no one else is captain
             if is_squad_captain:
-                await db.execute("UPDATE tournament_players SET is_squad_captain = ? WHERE tournament_id = ? AND squad_id = ? AND player_id != ?",
-                                 (False, self.tournament_id, self.squad_id, self.player_id))
+                await db.execute("UPDATE tournament_players SET is_squad_captain = ? WHERE tournament_id = ? AND registration_id = ? AND player_id != ?",
+                                 (False, self.tournament_id, self.registration_id, self.player_id))
             await db.execute("""UPDATE tournament_players SET mii_name = ?, can_host = ?, is_invite = ?, is_checked_in = ?, is_squad_captain = ?, 
                              selected_fc_id = ?, is_representative = ?, is_bagger_clause = ?, is_approved = ? WHERE id = ?""", (
                 self.mii_name, self.can_host, self.is_invite, is_checked_in, is_squad_captain, self.selected_fc_id, is_representative, is_bagger_clause, is_approved, registration_id))
@@ -227,7 +227,7 @@ class EditPlayerRegistrationCommand(Command[None]):
 @dataclass
 class UnregisterPlayerCommand(Command[None]):
     tournament_id: int
-    squad_id: int | None
+    registration_id: int | None
     player_id: int
     is_privileged: bool
 
@@ -240,15 +240,15 @@ class UnregisterPlayerCommand(Command[None]):
                 registrations_open = row[0]
                 if (not self.is_privileged) and (not registrations_open):
                     raise Problem("Registrations are closed, so players cannot be unregistered from this tournament", status=400)
-            async with db.execute("SELECT is_squad_captain, id FROM tournament_players WHERE tournament_id = ? AND squad_id iS ? AND player_id = ?",
-                                  (self.tournament_id, self.squad_id, self.player_id)) as cursor:
+            async with db.execute("SELECT is_squad_captain, id FROM tournament_players WHERE tournament_id = ? AND registration_id iS ? AND player_id = ?",
+                                  (self.tournament_id, self.registration_id, self.player_id)) as cursor:
                 row = await cursor.fetchone()
                 if not row:
                     raise Problem("Player is not registered for this tournament", status=400)
                 is_squad_captain, registration_id = row
-            if self.squad_id is not None:
+            if self.registration_id is not None:
                 # we should unregister a squad if it has no members remaining after this player is unregistered
-                async with db.execute("SELECT count(*) FROM tournament_players WHERE tournament_id = ? AND squad_id IS ? AND is_invite = 0", (self.tournament_id, self.squad_id)) as cursor:
+                async with db.execute("SELECT count(*) FROM tournament_players WHERE tournament_id = ? AND registration_id IS ? AND is_invite = 0", (self.tournament_id, self.registration_id)) as cursor:
                     row = await cursor.fetchone()
                     assert row is not None
                     num_squad_players = row[0]
@@ -256,11 +256,11 @@ class UnregisterPlayerCommand(Command[None]):
                 if is_squad_captain and num_squad_players > 1:
                     raise Problem("Please unregister your current squad or give captain to another player in your squad before unregistering for this tournament", status=400)
                 if is_squad_captain and num_squad_players == 1:
-                    await db.execute("UPDATE tournament_squads SET is_registered = ? WHERE id = ?", (False, self.squad_id))
+                    await db.execute("UPDATE tournament_registrations SET is_registered = ? WHERE id = ?", (False, self.registration_id))
                     # delete any invites as well
-                    await db.execute("DELETE FROM tournament_players WHERE tournament_id = ? AND squad_id IS ? AND is_invite = 1", (self.tournament_id, self.squad_id))
+                    await db.execute("DELETE FROM tournament_players WHERE tournament_id = ? AND registration_id IS ? AND is_invite = 1", (self.tournament_id, self.registration_id))
             await db.execute("DELETE FROM tournament_solo_placements WHERE tournament_id = ? AND player_id = ?", (self.tournament_id, registration_id))
-            async with db.execute("DELETE FROM tournament_players WHERE tournament_id = ? AND squad_id IS ? AND player_id = ?", (self.tournament_id, self.squad_id, self.player_id)) as cursor:
+            async with db.execute("DELETE FROM tournament_players WHERE tournament_id = ? AND registration_id IS ? AND player_id = ?", (self.tournament_id, self.registration_id, self.player_id)) as cursor:
                 rowcount = cursor.rowcount
                 if rowcount == 0:
                     raise Problem("Registration not found", status=404)
@@ -290,46 +290,46 @@ class GetSquadRegistrationsCommand(Command[list[TournamentSquadDetails]]):
             # get only squads which have the minimum number of players
             if self.eligible_only:
                 if min_squad_size:
-                    where_clauses.append("t.min_squad_size <= (SELECT COUNT(*) FROM tournament_players p WHERE p.tournament_id = s.tournament_id AND p.squad_id = s.id AND p.is_invite = 0)")
+                    where_clauses.append("t.min_squad_size <= (SELECT COUNT(*) FROM tournament_players p WHERE p.tournament_id = s.tournament_id AND p.registration_id = s.id AND p.is_invite = 0)")
                 if bool(checkins_enabled) and min_players_checkin is not None:
-                    where_clauses.append("t.min_players_checkin <= (SELECT COUNT(*) FROM tournament_players p WHERE p.tournament_id = s.tournament_id AND p.squad_id = s.id AND p.is_invite = 0 AND p.is_checked_in = 1)")
+                    where_clauses.append("t.min_players_checkin <= (SELECT COUNT(*) FROM tournament_players p WHERE p.tournament_id = s.tournament_id AND p.registration_id = s.id AND p.is_invite = 0 AND p.is_checked_in = 1)")
             if self.hosts_only:
-                where_clauses.append("EXISTS (SELECT p.id FROM tournament_players p WHERE p.tournament_id = s.tournament_id AND p.squad_id = s.id AND p.can_host = 1)")
+                where_clauses.append("EXISTS (SELECT p.id FROM tournament_players p WHERE p.tournament_id = s.tournament_id AND p.registration_id = s.id AND p.can_host = 1)")
             if self.is_approved is not None and bool(verification_required):
                 where_clauses.append("s.is_approved = ?")
                 variable_parameters.append(self.is_approved)
             where_clause = " AND ".join(where_clauses)
             squads: dict[int, TournamentSquadDetails] = {}
             async with db.execute(f"""SELECT s.id, s.name, s.tag, s.color, s.timestamp, s.is_registered, s.is_approved
-                                  FROM tournament_squads s
+                                  FROM tournament_registrations s
                                   JOIN tournaments t ON s.tournament_id = t.id
                                   WHERE {where_clause}""", variable_parameters) as cursor:
                 rows = await cursor.fetchall()
                 
                 for row in rows:
-                    squad_id, squad_name, squad_tag, squad_color, squad_timestamp, is_registered, is_approved = row
-                    curr_squad = TournamentSquadDetails(squad_id, squad_name, squad_tag, squad_color, squad_timestamp, is_registered, is_approved, [], [])
-                    squads[squad_id] = curr_squad
+                    registration_id, squad_name, squad_tag, squad_color, squad_timestamp, is_registered, is_approved = row
+                    curr_squad = TournamentSquadDetails(registration_id, squad_name, squad_tag, squad_color, squad_timestamp, is_registered, is_approved, [], [])
+                    squads[registration_id] = curr_squad
             # get teams connected to squads
             if teams_allowed:
-                async with db.execute(f"""SELECT tsr.squad_id, tr.id, tr.team_id, tr.name, tr.tag, t.name, t.tag, t.color
+                async with db.execute(f"""SELECT tsr.registration_id, tr.id, tr.team_id, tr.name, tr.tag, t.name, t.tag, t.color
                                     FROM team_squad_registrations tsr
                                     JOIN team_rosters tr ON tsr.roster_id = tr.id
                                     JOIN teams t ON tr.team_id = t.id
-                                    WHERE tsr.squad_id IN (
-                                        SELECT s.id FROM tournament_squads s
+                                    WHERE tsr.registration_id IN (
+                                        SELECT s.id FROM tournament_registrations s
                                         JOIN tournaments t ON s.tournament_id = t.id
                                         WHERE {where_clause}
                                     )""", variable_parameters) as cursor:
                     rows = await cursor.fetchall()
                     for row in rows:
-                        squad_id, roster_id, team_id, roster_name, roster_tag, team_name, team_tag, team_color = row
+                        registration_id, roster_id, team_id, roster_name, roster_tag, team_name, team_tag, team_color = row
                         roster = RosterBasic(team_id, team_name, team_tag, team_color, roster_id, roster_name if roster_name else team_name, roster_tag if roster_tag else team_tag)
-                        squad = squads.get(squad_id, None)
+                        squad = squads.get(registration_id, None)
                         if squad:
                             squad.rosters.append(roster)
             # get tournament players
-            async with db.execute("""SELECT t.id, t.player_id, t.squad_id, t.is_squad_captain, t.is_representative, t.timestamp, t.is_checked_in, 
+            async with db.execute("""SELECT t.id, t.player_id, t.registration_id, t.is_squad_captain, t.is_representative, t.timestamp, t.is_checked_in, 
                                     t.mii_name, t.can_host, t.is_invite, t.selected_fc_id, t.is_bagger_clause, t.is_approved, p.name, p.country_code, 
                                     d.discord_id, d.username, d.discriminator, d.global_name, d.avatar
                                     FROM tournament_players t
@@ -342,17 +342,17 @@ class GetSquadRegistrationsCommand(Command[list[TournamentSquadDetails]]):
                 rows = await cursor.fetchall()
                 player_fc_dict: dict[int, list[FriendCode]] = {} # create a dictionary of player fcs so we can give all players their FCs
                 for row in rows:
-                    (reg_id, player_id, squad_id, is_squad_captain, is_representative, player_timestamp, is_checked_in, mii_name, can_host, is_invite, selected_fc_id, 
+                    (reg_id, player_id, registration_id, is_squad_captain, is_representative, player_timestamp, is_checked_in, mii_name, can_host, is_invite, selected_fc_id, 
                      is_bagger_clause, is_approved, player_name, country, 
                      discord_id, d_username, d_discriminator, d_global_name, d_avatar) = row
-                    if squad_id not in squads:
+                    if registration_id not in squads:
                         continue
                     player_discord = None
                     if discord_id:
                         player_discord = Discord(discord_id, d_username, d_discriminator, d_global_name, d_avatar)
-                    curr_player = SquadPlayerDetails(reg_id, player_id, squad_id, player_timestamp, is_checked_in, is_approved, mii_name, can_host, player_name, country, player_discord, selected_fc_id, [], is_squad_captain, 
+                    curr_player = SquadPlayerDetails(reg_id, player_id, registration_id, player_timestamp, is_checked_in, is_approved, mii_name, can_host, player_name, country, player_discord, selected_fc_id, [], is_squad_captain, 
                                                      is_representative, is_invite, is_bagger_clause)
-                    curr_squad = squads[squad_id]
+                    curr_squad = squads[registration_id]
                     curr_squad.players.append(curr_player)
                     player_fc_dict[player_id] = []
             # gathering all the valid FCs for each player for this tournament
@@ -450,42 +450,42 @@ class GetPlayerSquadRegCommand(Command[MyTournamentRegistrationDetails]):
                     raise Problem("Tournament not found", status=400)
                 game, teams_allowed = row
             # get squads that the player is either in or has been invited to
-            async with db.execute("""SELECT id, name, tag, color, timestamp, is_registered, is_approved FROM tournament_squads s
+            async with db.execute("""SELECT id, name, tag, color, timestamp, is_registered, is_approved FROM tournament_registrations s
                                   WHERE s.tournament_id = ? AND s.id IN (
-                                    SELECT p.squad_id FROM tournament_players p
+                                    SELECT p.registration_id FROM tournament_players p
                                     WHERE p.player_id = ?
                                   )
                                 """, (self.tournament_id, self.player_id)) as cursor:
                 rows = await cursor.fetchall()
                 squads: dict[int, TournamentSquadDetails] = {}
                 for row in rows:
-                    squad_id, squad_name, squad_tag, squad_color, squad_timestamp, is_registered, is_approved = row
-                    curr_squad = TournamentSquadDetails(squad_id, squad_name, squad_tag, squad_color, squad_timestamp, is_registered, is_approved, [], [])
-                    squads[squad_id] = curr_squad
+                    registration_id, squad_name, squad_tag, squad_color, squad_timestamp, is_registered, is_approved = row
+                    curr_squad = TournamentSquadDetails(registration_id, squad_name, squad_tag, squad_color, squad_timestamp, is_registered, is_approved, [], [])
+                    squads[registration_id] = curr_squad
 
             # get teams connected to squads
             if teams_allowed:
-                async with db.execute("""SELECT tsr.squad_id, tr.id, tr.team_id, tr.name, tr.tag, t.name, t.tag, t.color
+                async with db.execute("""SELECT tsr.registration_id, tr.id, tr.team_id, tr.name, tr.tag, t.name, t.tag, t.color
                                     FROM team_squad_registrations tsr
                                     JOIN team_rosters tr ON tsr.roster_id = tr.id
                                     JOIN teams t ON tr.team_id = t.id
-                                    WHERE tsr.squad_id IN (
-                                        SELECT s.id FROM tournament_squads s
+                                    WHERE tsr.registration_id IN (
+                                        SELECT s.id FROM tournament_registrations s
                                         WHERE s.tournament_id = ? AND s.id IN (
-                                            SELECT p.squad_id FROM tournament_players p
+                                            SELECT p.registration_id FROM tournament_players p
                                             WHERE p.player_id = ?
                                         )
                                     )""", (self.tournament_id, self.player_id)) as cursor:
                     rows = await cursor.fetchall()
                     for row in rows:
-                        squad_id, roster_id, team_id, roster_name, roster_tag, team_name, team_tag, team_color = row
+                        registration_id, roster_id, team_id, roster_name, roster_tag, team_name, team_tag, team_color = row
                         roster = RosterBasic(team_id, team_name, team_tag, team_color, roster_id, roster_name if roster_name else team_name, roster_tag if roster_tag else team_tag)
-                        squad = squads.get(squad_id, None)
+                        squad = squads.get(registration_id, None)
                         if squad:
                             squad.rosters.append(roster)
 
             # get all players from squads that the requested player is in
-            async with db.execute("""SELECT t.id, t.player_id, t.squad_id, t.is_squad_captain, t.is_representative, t.timestamp, t.is_checked_in, 
+            async with db.execute("""SELECT t.id, t.player_id, t.registration_id, t.is_squad_captain, t.is_representative, t.timestamp, t.is_checked_in, 
                                     t.mii_name, t.can_host, t.is_invite, t.selected_fc_id, t.is_bagger_clause, t.is_approved, p.name, p.country_code, 
                                     d.discord_id, d.username, d.discriminator, d.global_name, d.avatar
                                     FROM tournament_players t
@@ -493,34 +493,34 @@ class GetPlayerSquadRegCommand(Command[MyTournamentRegistrationDetails]):
                                     LEFT JOIN users u ON u.player_id = p.id
                                     LEFT JOIN user_discords d ON u.id = d.user_id
                                     WHERE t.tournament_id = ?
-                                    AND t.squad_id IN (
-                                        SELECT p2.squad_id FROM tournament_players p2
+                                    AND t.registration_id IN (
+                                        SELECT p2.registration_id FROM tournament_players p2
                                         WHERE p2.player_id = ?
                                     )
                                     ORDER BY p.name COLLATE NOCASE""", (self.tournament_id, self.player_id)) as cursor:
                 rows = await cursor.fetchall()
                 player_fc_dict: dict[int, list[FriendCode]] = {} # create a dictionary of player fcs so we can give all players their FCs
                 for row in rows:
-                    (reg_id, player_id, squad_id, is_squad_captain, is_representative, player_timestamp, is_checked_in, mii_name, can_host, 
+                    (reg_id, player_id, registration_id, is_squad_captain, is_representative, player_timestamp, is_checked_in, mii_name, can_host, 
                      is_invite, selected_fc_id, is_bagger_clause, is_approved, player_name, country, 
                      discord_id, d_username, d_discriminator, d_global_name, d_avatar) = row
-                    if squad_id not in squads:
+                    if registration_id not in squads:
                         continue
                     player_discord = None
                     if discord_id:
                         player_discord = Discord(discord_id, d_username, d_discriminator, d_global_name, d_avatar)
-                    curr_player = SquadPlayerDetails(reg_id, player_id, squad_id, player_timestamp, is_checked_in, is_approved,
+                    curr_player = SquadPlayerDetails(reg_id, player_id, registration_id, player_timestamp, is_checked_in, is_approved,
                                                      mii_name, can_host, player_name, country, player_discord, selected_fc_id, [], is_squad_captain,
                                                      is_representative, is_invite, is_bagger_clause)
-                    curr_squad = squads[squad_id]
+                    curr_squad = squads[registration_id]
                     curr_squad.players.append(curr_player)
                     player_fc_dict[player_id] = []
 
             # gathering all the valid FCs for each player in their squads
             fc_type = game_fc_map[game]
             fc_query = f"""SELECT id, player_id, type, fc, is_verified, is_primary, description, is_active, creation_date FROM friend_codes f WHERE f.type = ? AND player_id IN (
-                            SELECT t.player_id FROM tournament_players t WHERE t.tournament_id = ? AND t.squad_id IN (
-                                SELECT p2.squad_id FROM tournament_players p2
+                            SELECT t.player_id FROM tournament_players t WHERE t.tournament_id = ? AND t.registration_id IN (
+                                SELECT p2.registration_id FROM tournament_players p2
                                 WHERE p2.player_id = ?
                             )
                         )"""
@@ -593,7 +593,7 @@ class GetPlayerSoloRegCommand(Command[MyTournamentRegistrationDetails]):
 @dataclass
 class TogglePlayerCheckinCommand(Command[None]):
     tournament_id: int
-    squad_id: int | None
+    registration_id: int | None
     player_id: int
 
     async def handle(self, db_wrapper, s3_wrapper):
@@ -608,12 +608,12 @@ class TogglePlayerCheckinCommand(Command[None]):
                     raise Problem("Checkins are not enabled for this tournament", status=400)
                 if not checkins_open:
                     raise Problem("Checkins are not open for this tournament", status=400)
-            async with db.execute("SELECT is_checked_in FROM tournament_players where tournament_id = ? AND squad_id IS ? AND player_id = ?",
-                                  (self.tournament_id, self.squad_id, self.player_id)) as cursor:
+            async with db.execute("SELECT is_checked_in FROM tournament_players where tournament_id = ? AND registration_id IS ? AND player_id = ?",
+                                  (self.tournament_id, self.registration_id, self.player_id)) as cursor:
                 row = await cursor.fetchone()
                 if not row:
                     raise Problem("Player not registered for tournament", status=400)
                 is_checked_in = bool(row[0])
-            await db.execute("UPDATE tournament_players SET is_checked_in = ? WHERE tournament_id = ? AND squad_id IS ? AND player_id = ?",
-                                  (not is_checked_in, self.tournament_id, self.squad_id, self.player_id))
+            await db.execute("UPDATE tournament_players SET is_checked_in = ? WHERE tournament_id = ? AND registration_id IS ? AND player_id = ?",
+                                  (not is_checked_in, self.tournament_id, self.registration_id, self.player_id))
             await db.commit()

--- a/src/backend/common/data/commands/tournaments/squads.py
+++ b/src/backend/common/data/commands/tournaments/squads.py
@@ -342,7 +342,8 @@ class UnregisterSquadCommand(Command[None]):
         async with db_wrapper.connect() as db:
             await db.execute("DELETE FROM tournament_players WHERE registration_id = ? AND tournament_id = ?", (self.registration_id, self.tournament_id))
             await db.execute("DELETE FROM team_squad_registrations WHERE registration_id = ? AND tournament_id = ?", (self.registration_id, self.tournament_id))
-            await db.execute("UPDATE tournament_registrations SET is_registered = 0 WHERE id = ? AND tournament_id = ?", (self.registration_id, self.tournament_id))
+            await db.execute("DELETE FROM tournament_placements WHERE registration_id = ?", (self.registration_id,))
+            await db.execute("DELETE FROM tournament_registrations WHERE id = ?", (self.registration_id,))
             await db.commit()
 
 @dataclass

--- a/src/backend/common/data/commands/tournaments/squads.py
+++ b/src/backend/common/data/commands/tournaments/squads.py
@@ -478,12 +478,12 @@ class AddRosterToSquadCommand(Command[None]):
                                     )
                                   """, (self.roster_id, self.tournament_id, False)) as cursor:
                 rows = await cursor.fetchall()
-                new_players = [(row[0], self.tournament_id, self.registration_id, False, now, False, None, False, False, None, False, False) for row in rows]
+                new_players = [(row[0], self.tournament_id, self.registration_id, False, now, False, None, False, False, None, False, False, False) for row in rows]
             
             await db.execute("INSERT INTO team_squad_registrations(roster_id, registration_id, tournament_id) VALUES(?, ?, ?)", (self.roster_id, self.registration_id, self.tournament_id))
             await db.executemany("""INSERT INTO tournament_players(player_id, tournament_id, registration_id, is_squad_captain, timestamp, is_checked_in,
-                                mii_name, can_host, is_invite, selected_fc_id, is_representative, is_approved)
-                                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""", (new_players))
+                                mii_name, can_host, is_invite, selected_fc_id, is_representative, is_approved, is_bagger_clause)
+                                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""", (new_players))
             await db.commit()
 
 @dataclass

--- a/src/backend/common/data/commands/users/notifications.py
+++ b/src/backend/common/data/commands/users/notifications.py
@@ -219,16 +219,16 @@ class GetTeamManagerAndLeaderUserIdsCommand(Command[List[int]]):
 @dataclass
 class GetNotificationSquadDataCommand(Command[NotificationDataTournamentSquad]):
     tournament_id: int
-    squad_id: int
+    registration_id: int
 
     async def handle(self, db_wrapper, s3_wrapper):
         async with db_wrapper.connect(readonly=True) as db:
             query = """SELECT s.name, t.name, u.id FROM tournament_players tp 
                 JOIN users u ON tp.player_id = u.player_id 
-                JOIN tournament_squads s ON s.id = tp.squad_id 
+                JOIN tournament_registrations s ON s.id = tp.registration_id 
                 JOIN tournaments t ON t.id = tp.tournament_id 
-                WHERE t.id = ? AND tp.squad_id = ? AND tp.is_squad_captain = TRUE"""
-            async with db.execute(query, (self.tournament_id, self.squad_id)) as cursor:
+                WHERE t.id = ? AND tp.registration_id = ? AND tp.is_squad_captain = TRUE"""
+            async with db.execute(query, (self.tournament_id, self.registration_id)) as cursor:
                 row = await cursor.fetchone()
                 if row is None:
                     raise Problem("Dispatching notification failed to query squad data", status=500)

--- a/src/backend/common/data/commands/users/users.py
+++ b/src/backend/common/data/commands/users/users.py
@@ -87,7 +87,7 @@ class GetInvitesForPlayerCommand(Command[PlayerInvites]):
             async with db.execute("""SELECT i.id, i.tournament_id, i.timestamp, i.is_bagger_clause, s.name, s.tag, s.color,
                                     t.name, t.game, t.mode
                                     FROM tournament_players i
-                                    JOIN tournament_squads s ON i.squad_id = s.id
+                                    JOIN tournament_registrations s ON i.registration_id = s.id
                                     JOIN tournaments t ON i.tournament_id = t.id
                                     WHERE i.is_invite = 1 AND i.player_id = ?
                                     AND t.registrations_open = 1""", (self.player_id,)) as cursor:

--- a/src/backend/common/data/db/indices.py
+++ b/src/backend/common/data/db/indices.py
@@ -70,8 +70,15 @@ class TournamentSquadPlacementsTournamentID(IndexModel):
         return """CREATE INDEX IF NOT EXISTS tournament_placements_tournament_id
             ON tournament_placements(tournament_id)"""
     
+@dataclass
+class TeamMembersRosterID(IndexModel):
+    @staticmethod
+    def get_create_index_command() -> str:
+        return """CREATE INDEX IF NOT EXISTS team_members_roster_id
+            ON team_members(roster_id)"""
+    
 all_indices : list[type[IndexModel]] = [
     UserRolesExpiresOn, UserTeamRolesExpiresOn, UserSeriesRolesExpiresOn, UserTournamentRolesExpiresOn,
     TournamentSquadsTournamentID, TournamentPlayersTournamentIDSquadID, FriendCodesType, FriendCodesPlayerID,
-    TournamentSquadPlacementsTournamentID,
+    TournamentSquadPlacementsTournamentID, TeamMembersRosterID
 ]

--- a/src/backend/common/data/db/indices.py
+++ b/src/backend/common/data/db/indices.py
@@ -39,15 +39,15 @@ class UserTournamentRolesExpiresOn(IndexModel):
 class TournamentSquadsTournamentID(IndexModel):
     @staticmethod
     def get_create_index_command() -> str:
-        return """CREATE INDEX IF NOT EXISTS tournament_squads_tournament_id
-            ON tournament_squads (tournament_id)"""
+        return """CREATE INDEX IF NOT EXISTS tournament_registrations_tournament_id
+            ON tournament_registrations (tournament_id)"""
     
 @dataclass
 class TournamentPlayersTournamentIDSquadID(IndexModel):
     @staticmethod
     def get_create_index_command() -> str:
-        return """CREATE INDEX IF NOT EXISTS tournament_players_tournament_id_squad_id
-            ON tournament_players (tournament_id, squad_id)"""
+        return """CREATE INDEX IF NOT EXISTS tournament_players_tournament_id_registration_id
+            ON tournament_players (tournament_id, registration_id)"""
     
 @dataclass
 class FriendCodesType(IndexModel):

--- a/src/backend/common/data/db/indices.py
+++ b/src/backend/common/data/db/indices.py
@@ -62,24 +62,16 @@ class FriendCodesPlayerID(IndexModel):
     def get_create_index_command() -> str:
         return """CREATE INDEX IF NOT EXISTS friend_codes_player_id
             ON friend_codes (player_id)"""
-
-@dataclass
-class TournamentSoloPlacementsTournamentID(IndexModel):
-    @staticmethod
-    def get_create_index_command() -> str:
-        return """CREATE INDEX IF NOT EXISTS tournament_solo_placements_tournament_id
-            ON tournament_solo_placements(tournament_id)"""
     
 @dataclass
 class TournamentSquadPlacementsTournamentID(IndexModel):
     @staticmethod
     def get_create_index_command() -> str:
-        return """CREATE INDEX IF NOT EXISTS tournament_squad_placements_tournament_id
-            ON tournament_squad_placements(tournament_id)"""
+        return """CREATE INDEX IF NOT EXISTS tournament_placements_tournament_id
+            ON tournament_placements(tournament_id)"""
     
-
 all_indices : list[type[IndexModel]] = [
     UserRolesExpiresOn, UserTeamRolesExpiresOn, UserSeriesRolesExpiresOn, UserTournamentRolesExpiresOn,
     TournamentSquadsTournamentID, TournamentPlayersTournamentIDSquadID, FriendCodesType, FriendCodesPlayerID,
-    TournamentSoloPlacementsTournamentID, TournamentSquadPlacementsTournamentID
+    TournamentSquadPlacementsTournamentID,
 ]

--- a/src/backend/common/data/db/indices.py
+++ b/src/backend/common/data/db/indices.py
@@ -50,6 +50,13 @@ class TournamentPlayersTournamentIDSquadID(IndexModel):
             ON tournament_players (tournament_id, registration_id)"""
     
 @dataclass
+class TournamentPlayersPlayerID(IndexModel):
+    @staticmethod
+    def get_create_index_command() -> str:
+        return """CREATE INDEX IF NOT EXISTS tournament_players_player_id
+            ON tournament_players(player_id)"""
+    
+@dataclass
 class FriendCodesType(IndexModel):
     @staticmethod
     def get_create_index_command() -> str:

--- a/src/backend/common/data/db/tables.py
+++ b/src/backend/common/data/db/tables.py
@@ -328,7 +328,7 @@ class TournamentTemplate(TableModel):
             series_id INTEGER REFERENCES tournament_series(id))"""
 
 @dataclass
-class TournamentSquad(TableModel):
+class TournamentRegistration(TableModel):
     id: int
     name: str | None
     tag: str | None
@@ -340,7 +340,7 @@ class TournamentSquad(TableModel):
 
     @staticmethod
     def get_create_table_command():
-        return """CREATE TABLE IF NOT EXISTS tournament_squads(
+        return """CREATE TABLE IF NOT EXISTS tournament_registrations(
             id INTEGER PRIMARY KEY,
             name TEXT,
             tag TEXT,
@@ -356,7 +356,7 @@ class TournamentPlayer(TableModel):
     id: int
     player_id: int
     tournament_id: int
-    squad_id: int | None
+    registration_id: int | None
     is_squad_captain: bool
     timestamp: int
     is_checked_in: bool
@@ -374,7 +374,7 @@ class TournamentPlayer(TableModel):
             id INTEGER PRIMARY KEY,
             player_id INTEGER NOT NULL REFERENCES players(id),
             tournament_id INTEGER NOT NULL REFERENCES tournaments(id),
-            squad_id INTEGER REFERENCES tournament_squads(id),
+            registration_id INTEGER REFERENCES tournament_registrations(id),
             is_squad_captain BOOLEAN NOT NULL,
             timestamp INTEGER NOT NULL,
             is_checked_in BOOLEAN NOT NULL,
@@ -413,7 +413,7 @@ class TournamentSoloPlacements(TableModel):
 class TournamentSquadPlacements(TableModel):
     id: int
     tournament_id: int
-    squad_id: int
+    registration_id: int
     placement: int
     placement_description: str | None
     placement_lower_bound: int | None
@@ -424,7 +424,7 @@ class TournamentSquadPlacements(TableModel):
         return """CREATE TABLE IF NOT EXISTS tournament_squad_placements(
             id INTEGER PRIMARY KEY,
             tournament_id INTEGER NOT NULL REFERENCES tournaments(id),
-            squad_id INTEGER NOT NULL REFERENCES tournament_squads(id),
+            registration_id INTEGER NOT NULL REFERENCES tournament_registrations(id),
             placement INTEGER,
             placement_description TEXT,
             placement_lower_bound INTEGER,
@@ -513,16 +513,16 @@ class TeamMember(TableModel):
 @dataclass
 class TeamSquadRegistration(TableModel):
     roster_id: int
-    squad_id: int
+    registration_id: int
     tournament_id: int
 
     @staticmethod
     def get_create_table_command() -> str:
         return """CREATE TABLE IF NOT EXISTS team_squad_registrations(
             roster_id INTEGER NOT NULL,
-            squad_id INTEGER NOT NULL,
+            registration_id INTEGER NOT NULL,
             tournament_id INTEGER NOT NULL,
-            PRIMARY KEY (roster_id, squad_id, tournament_id)
+            PRIMARY KEY (roster_id, registration_id, tournament_id)
             ) WITHOUT ROWID
             """
 
@@ -1098,7 +1098,7 @@ class UserIP(TableModel):
     
 all_tables : list[type[TableModel]] = [
     Player, FriendCode, User, Session, UserDiscord, Role, Permission, UserRole, RolePermission, 
-    TournamentSeries, Tournament, TournamentTemplate, TournamentSquad, TournamentPlayer,
+    TournamentSeries, Tournament, TournamentTemplate, TournamentRegistration, TournamentPlayer,
     TournamentSoloPlacements, TournamentSquadPlacements, Team, TeamRoster, TeamMember, 
     TeamSquadRegistration, TeamRole, TeamPermission, TeamRolePermission, UserTeamRole,
     SeriesRole, SeriesPermission, SeriesRolePermission, UserSeriesRole, 

--- a/src/backend/common/data/db/tables.py
+++ b/src/backend/common/data/db/tables.py
@@ -356,7 +356,7 @@ class TournamentPlayer(TableModel):
     id: int
     player_id: int
     tournament_id: int
-    registration_id: int | None
+    registration_id: int
     is_squad_captain: bool
     timestamp: int
     is_checked_in: bool
@@ -374,7 +374,7 @@ class TournamentPlayer(TableModel):
             id INTEGER PRIMARY KEY,
             player_id INTEGER NOT NULL REFERENCES players(id),
             tournament_id INTEGER NOT NULL REFERENCES tournaments(id),
-            registration_id INTEGER REFERENCES tournament_registrations(id),
+            registration_id INTEGER NOT NULL REFERENCES tournament_registrations(id),
             is_squad_captain BOOLEAN NOT NULL,
             timestamp INTEGER NOT NULL,
             is_checked_in BOOLEAN NOT NULL,
@@ -388,29 +388,7 @@ class TournamentPlayer(TableModel):
             )"""
     
 @dataclass
-class TournamentSoloPlacements(TableModel):
-    id: int
-    tournament_id: int
-    player_id: int
-    placement: int
-    placement_description: str | None
-    placement_lower_bound: int | None
-    is_disqualified: bool
-
-    @staticmethod
-    def get_create_table_command() -> str:
-        return """CREATE TABLE IF NOT EXISTS tournament_solo_placements(
-            id INTEGER PRIMARY KEY,
-            tournament_id INTEGER NOT NULL REFERENCES tournaments(id),
-            player_id INTEGER NOT NULL REFERENCES tournament_players(id),
-            placement INTEGER,
-            placement_description TEXT,
-            placement_lower_bound INTEGER,
-            is_disqualified BOOLEAN NOT NULL
-        )"""
-    
-@dataclass
-class TournamentSquadPlacements(TableModel):
+class TournamentPlacements(TableModel):
     id: int
     tournament_id: int
     registration_id: int
@@ -421,7 +399,7 @@ class TournamentSquadPlacements(TableModel):
 
     @staticmethod
     def get_create_table_command() -> str:
-        return """CREATE TABLE IF NOT EXISTS tournament_squad_placements(
+        return """CREATE TABLE IF NOT EXISTS tournament_placements(
             id INTEGER PRIMARY KEY,
             tournament_id INTEGER NOT NULL REFERENCES tournaments(id),
             registration_id INTEGER NOT NULL REFERENCES tournament_registrations(id),
@@ -1099,7 +1077,7 @@ class UserIP(TableModel):
 all_tables : list[type[TableModel]] = [
     Player, FriendCode, User, Session, UserDiscord, Role, Permission, UserRole, RolePermission, 
     TournamentSeries, Tournament, TournamentTemplate, TournamentRegistration, TournamentPlayer,
-    TournamentSoloPlacements, TournamentSquadPlacements, Team, TeamRoster, TeamMember, 
+    TournamentPlacements, Team, TeamRoster, TeamMember, 
     TeamSquadRegistration, TeamRole, TeamPermission, TeamRolePermission, UserTeamRole,
     SeriesRole, SeriesPermission, SeriesRolePermission, UserSeriesRole, 
     TournamentRole, TournamentPermission, TournamentRolePermission, UserTournamentRole,

--- a/src/backend/common/data/models/mkcv1.py
+++ b/src/backend/common/data/models/mkcv1.py
@@ -463,7 +463,7 @@ class NewMKCTournamentPlayer:
     id: int
     player_id: int
     tournament_id: int
-    squad_id: int | None
+    registration_id: int | None
     is_squad_captain: bool
     timestamp: int
     is_checked_in: bool
@@ -477,7 +477,7 @@ class NewMKCTournamentPlayer:
 @dataclass
 class NewMKCRosterSquadLink:
     roster_id: int
-    squad_id: int
+    registration_id: int
     tournament_id: int
 
 @dataclass
@@ -492,7 +492,7 @@ class NewMKCSoloPlacement:
 @dataclass
 class NewMKCSquadPlacement:
     tournament_id: int
-    squad_id: int
+    registration_id: int
     placement: int | None
     placement_description: str | None
     placement_lower_bound: int | None

--- a/src/backend/common/data/models/mkcv1.py
+++ b/src/backend/common/data/models/mkcv1.py
@@ -463,7 +463,7 @@ class NewMKCTournamentPlayer:
     id: int
     player_id: int
     tournament_id: int
-    registration_id: int | None
+    registration_id: int
     is_squad_captain: bool
     timestamp: int
     is_checked_in: bool

--- a/src/backend/common/data/models/players.py
+++ b/src/backend/common/data/models/players.py
@@ -115,7 +115,7 @@ class PlayerFilter:
     discord_id: str | None = None
     detailed: bool | None = None
     page: int | None = None
-    squad_id: int | None = None
+    registration_id: int | None = None
     matching_fcs_only: bool = False
     include_shadow_players: bool = False
     sort_by_newest: bool | None = False

--- a/src/backend/common/data/models/squads.py
+++ b/src/backend/common/data/models/squads.py
@@ -28,7 +28,7 @@ class ForceCreateSquadRequestData(CreateSquadRequestData):
 
 @dataclass
 class EditMySquadRequestData:
-    squad_id: int
+    registration_id: int
     squad_name: str | None
     squad_tag: str | None
     squad_color: int | None
@@ -40,30 +40,30 @@ class EditSquadRequestData(EditMySquadRequestData):
 
 @dataclass
 class InvitePlayerRequestData:
-    squad_id: int
+    registration_id: int
     player_id: int
     is_representative: bool = False
     is_bagger_clause: bool = False
 
 @dataclass
 class KickSquadPlayerRequestData:
-    squad_id: int
+    registration_id: int
     player_id: int
 
 @dataclass
 class AcceptInviteRequestData():
-    squad_id: int
+    registration_id: int
     mii_name: str | None
     can_host: bool
     selected_fc_id: int | None
 
 @dataclass
 class DeclineInviteRequestData():
-    squad_id: int
+    registration_id: int
 
 @dataclass
 class UnregisterPlayerRequestData():
-    squad_id: int | None
+    registration_id: int | None
 
 @dataclass
 class StaffUnregisterPlayerRequestData(UnregisterPlayerRequestData):
@@ -102,12 +102,12 @@ class MyTournamentRegistrationDetails():
 
 @dataclass
 class MakeCaptainRequestData():
-    squad_id: int
+    registration_id: int
     player_id: int
 
 @dataclass
 class UnregisterSquadRequestData():
-    squad_id: int
+    registration_id: int
 
 @dataclass
 class TeamTournamentPlayer():
@@ -126,5 +126,5 @@ class RegisterTeamRequestData():
 
 @dataclass
 class AddRemoveRosterRequestData:
-    squad_id: int
+    registration_id: int
     roster_id: int

--- a/src/backend/common/data/models/squads.py
+++ b/src/backend/common/data/models/squads.py
@@ -63,7 +63,7 @@ class DeclineInviteRequestData():
 
 @dataclass
 class UnregisterPlayerRequestData():
-    registration_id: int | None
+    registration_id: int
 
 @dataclass
 class StaffUnregisterPlayerRequestData(UnregisterPlayerRequestData):
@@ -88,10 +88,9 @@ class TournamentSquadDetails():
     players: list[SquadPlayerDetails]
     rosters: list[RosterBasic]
 
-
 @dataclass
 class MyTournamentRegistration():
-    squad: TournamentSquadDetails | None
+    squad: TournamentSquadDetails
     player: TournamentPlayerDetails
 
 @dataclass

--- a/src/backend/common/data/models/squads.py
+++ b/src/backend/common/data/models/squads.py
@@ -91,7 +91,9 @@ class TournamentSquadDetails():
 @dataclass
 class MyTournamentRegistration():
     squad: TournamentSquadDetails
-    player: TournamentPlayerDetails
+    player: TournamentPlayerDetails | None
+    is_squad_captain: bool
+    is_invite: bool
 
 @dataclass
 class MyTournamentRegistrationDetails():

--- a/src/backend/common/data/models/tournament_placements.py
+++ b/src/backend/common/data/models/tournament_placements.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from common.data.models import TournamentPlayerDetails, TournamentSquadDetails
+from common.data.models import TournamentSquadDetails
 from common.data.models.tournament_registrations import TournamentPlayerDetailsShort
 
 @dataclass
@@ -20,13 +20,11 @@ class TournamentPlacementFromPlayerIDs():
 
 @dataclass
 class TournamentPlacementDetailed(TournamentPlacement):
-    player: TournamentPlayerDetails | None
-    squad: TournamentSquadDetails | None
+    squad: TournamentSquadDetails
 
 @dataclass
 class TournamentPlacementList():
     tournament_id: int
-    is_squad: bool
     placements: list[TournamentPlacementDetailed]
     unplaced: list[TournamentPlacementDetailed]
 
@@ -36,7 +34,7 @@ class PlayerTournamentPlacement():
     tournament_name: str
     game: str
     mode: str
-    registration_id: int | None
+    registration_id: int
     squad_name: str | None
     team_id: int | None
     date_start: int

--- a/src/backend/common/data/models/tournament_placements.py
+++ b/src/backend/common/data/models/tournament_placements.py
@@ -36,7 +36,7 @@ class PlayerTournamentPlacement():
     tournament_name: str
     game: str
     mode: str
-    squad_id: int | None
+    registration_id: int | None
     squad_name: str | None
     team_id: int | None
     date_start: int

--- a/src/backend/common/data/models/tournament_registrations.py
+++ b/src/backend/common/data/models/tournament_registrations.py
@@ -24,7 +24,7 @@ class EditMyRegistrationRequestData():
     mii_name: str | None
     can_host: bool
     selected_fc_id: int | None
-    registration_id: int | None
+    registration_id: int
 
 @dataclass
 class EditPlayerRegistrationRequestData(EditMyRegistrationRequestData):
@@ -46,7 +46,7 @@ class TournamentPlayerDetailsShort():
 class TournamentPlayerDetails():
     id: int
     player_id: int
-    registration_id: int | None
+    registration_id: int
     timestamp: int
     is_checked_in: bool
     is_approved: bool
@@ -67,4 +67,4 @@ class TournamentRegistrationFilter():
 
 @dataclass
 class TournamentCheckinRequestData():
-    registration_id: int | None
+    registration_id: int

--- a/src/backend/common/data/models/tournament_registrations.py
+++ b/src/backend/common/data/models/tournament_registrations.py
@@ -11,7 +11,7 @@ class RegisterPlayerRequestData:
 @dataclass
 class ForceRegisterPlayerRequestData(RegisterPlayerRequestData):
     player_id: int
-    squad_id: int | None = None
+    registration_id: int | None = None
     is_squad_captain: bool = False
     is_invite: bool = False
     is_checked_in: bool = False
@@ -24,7 +24,7 @@ class EditMyRegistrationRequestData():
     mii_name: str | None
     can_host: bool
     selected_fc_id: int | None
-    squad_id: int | None
+    registration_id: int | None
 
 @dataclass
 class EditPlayerRegistrationRequestData(EditMyRegistrationRequestData):
@@ -40,13 +40,13 @@ class EditPlayerRegistrationRequestData(EditMyRegistrationRequestData):
 class TournamentPlayerDetailsShort():
     player_id: int
     player_name: str
-    squad_id: int
+    registration_id: int
 
 @dataclass
 class TournamentPlayerDetails():
     id: int
     player_id: int
-    squad_id: int | None
+    registration_id: int | None
     timestamp: int
     is_checked_in: bool
     is_approved: bool
@@ -67,4 +67,4 @@ class TournamentRegistrationFilter():
 
 @dataclass
 class TournamentCheckinRequestData():
-    squad_id: int | None
+    registration_id: int | None

--- a/src/frontend/src/lib/components/common/PlayerSearch.svelte
+++ b/src/frontend/src/lib/components/common/PlayerSearch.svelte
@@ -9,7 +9,7 @@
 
   export let player: PlayerInfo | null = null;
   export let fc_type: string | null = null;
-  export let squad_id: number | null = null;
+  export let registration_id: number | null = null;
   export let is_shadow: boolean | null = false;
   export let include_shadow_players = false;
   export let has_connected_user: boolean | null = null;
@@ -43,8 +43,8 @@
     if(fc_type) {
       query_parameters.push(`fc_type=${fc_type}`);
     }
-    if(squad_id) {
-      query_parameters.push(`squad_id=${squad_id}`);
+    if(registration_id) {
+      query_parameters.push(`registration_id=${registration_id}`);
     }
     if(is_shadow !== null) {
       query_parameters.push(`is_shadow=${is_shadow}`);

--- a/src/frontend/src/lib/components/homepage/LatestResults.svelte
+++ b/src/frontend/src/lib/components/homepage/LatestResults.svelte
@@ -102,7 +102,7 @@
         {/if}
         <div class="flex flex-col {playerPlacement ? 'mt-[14px]' : 'mt-[13px]'}">
             {#each placement_list as placement}
-                <PlacementItem {placement} is_squad={tournament.is_squad} is_edit={false} is_homepage={true}/>
+                <PlacementItem {placement} is_edit={false} is_homepage={true}/>
             {/each}
         </div>
     {/if}

--- a/src/frontend/src/lib/components/registry/players/PlayerTournamentHistory.svelte
+++ b/src/frontend/src/lib/components/registry/players/PlayerTournamentHistory.svelte
@@ -224,7 +224,7 @@
                     {toDate(placement.date_start)}
                     {placement.date_end == placement.date_start ? '' : ' - ' + toDate(placement.date_end)}
                   </td>
-                  {#if placement.squad_id != null && placement.squad_name != null}
+                  {#if placement.registration_id != null && placement.squad_name != null}
                     <td class="mobile-hide">
                       {#if placement.team_id}
                         <a

--- a/src/frontend/src/lib/components/tournaments/TournamentPlayerList.svelte
+++ b/src/frontend/src/lib/components/tournaments/TournamentPlayerList.svelte
@@ -42,7 +42,7 @@
       return;
     }
     const payload = {
-      squad_id: player.squad_id,
+      registration_id: player.registration_id,
       player_id: player.player_id
     };
     console.log(payload);
@@ -66,7 +66,7 @@
       return;
     }
     const payload = {
-      squad_id: player.squad_id,
+      registration_id: player.registration_id,
       player_id: player.player_id,
     };
     const endpoint = `/api/tournaments/${tournament.id}/kickPlayer`;
@@ -90,7 +90,7 @@
       return;
     }
     const payload = {
-      squad_id: player.squad_id,
+      registration_id: player.registration_id,
       player_id: player.player_id,
     };
     const endpoint = `/api/tournaments/${tournament.id}/makeCaptain`;
@@ -110,7 +110,7 @@
 
   async function addRepresentative(player: TournamentPlayer) {
     const payload = {
-      squad_id: player.squad_id,
+      registration_id: player.registration_id,
       player_id: player.player_id,
     };
     const endpoint = `/api/tournaments/${tournament.id}/addRepresentative`;
@@ -130,7 +130,7 @@
 
   async function removeRepresentative(player: TournamentPlayer) {
     const payload = {
-      squad_id: player.squad_id,
+      registration_id: player.registration_id,
       player_id: player.player_id,
     };
     const endpoint = `/api/tournaments/${tournament.id}/removeRepresentative`;
@@ -161,7 +161,7 @@
       return;
     }
     const payload = {
-      squad_id: my_player.squad_id,
+      registration_id: my_player.registration_id,
     };
     console.log(payload);
     const endpoint = `/api/tournaments/${tournament.id}/unregister`;
@@ -256,7 +256,7 @@
                 {/if}
                 <DropdownItem on:click={unregister}>{$LL.TOURNAMENTS.REGISTRATIONS.UNREGISTER()}</DropdownItem>
               </Dropdown>
-            {:else if my_player?.is_squad_captain && my_player?.squad_id === player.squad_id && check_registrations_open(tournament)}
+            {:else if my_player?.is_squad_captain && my_player?.registration_id === player.registration_id && check_registrations_open(tournament)}
               <ChevronDownSolid class="cursor-pointer"/>
               <Dropdown>
                 <DropdownItem on:click={() => kickPlayer(player)}>

--- a/src/frontend/src/lib/components/tournaments/TournamentRegistrations.svelte
+++ b/src/frontend/src/lib/components/tournaments/TournamentRegistrations.svelte
@@ -26,22 +26,7 @@
     user_info = value;
   });
 
-  onMount(async () => {
-    const res = await fetch(`/api/tournaments/${tournament.id}/registrations?is_approved=true`);
-    if (res.status < 300) {
-      const body = await res.json();
-      if (tournament.is_squad) {
-        tournament_squads = body;
-        registration_count = tournament_squads.length;
-      } else {
-        tournament_players = body;
-        registration_count = tournament_players.length;
-      }
-      registrations_loaded = true;
-    }
-  });
-
-  async function filter_registrations() {
+  async function fetchData() {
     let eligible_only = false;
     let hosts_only = false;
     let is_approved = true;
@@ -59,23 +44,28 @@
     const res = await fetch(url);
     if (res.status < 300) {
       const body = await res.json();
-      console.log(body);
-      if (tournament.is_squad) {
-        tournament_squads = body;
-        registration_count = tournament_squads.length;
-      } else {
-        tournament_players = body;
-        registration_count = tournament_players.length;
+      tournament_squads = body;
+      registration_count = tournament_squads.length;
+      console.log(tournament_squads);
+      if(!tournament.is_squad) {
+        tournament_players = tournament_squads.flatMap((squad) => squad.players);
+        
       }
       show_all = false;
+      registrations_loaded = true;
     }
   }
+
+  onMount(async () => {
+    await fetchData();
+  });
+
 </script>
 
 <div>
   {#if registrations_loaded}
     <div>
-      <select bind:value={setting} on:change={filter_registrations}>
+      <select bind:value={setting} on:change={fetchData}>
         <option value={'any'}>
           {$LL.TOURNAMENTS.REGISTRATIONS.ALL_REGISTRATIONS({is_squad: tournament.is_squad})}
         </option>

--- a/src/frontend/src/lib/components/tournaments/TournamentRegistrations.svelte
+++ b/src/frontend/src/lib/components/tournaments/TournamentRegistrations.svelte
@@ -69,7 +69,7 @@
         <option value={'any'}>
           {$LL.TOURNAMENTS.REGISTRATIONS.ALL_REGISTRATIONS({is_squad: tournament.is_squad})}
         </option>
-        {#if tournament.is_squad}
+        {#if tournament.is_squad || tournament.checkins_enabled}
           <option value={'eligible'}>{$LL.TOURNAMENTS.REGISTRATIONS.ELIGIBLE_ONLY()}</option>
         {/if}
         {#if tournament.host_status_required}

--- a/src/frontend/src/lib/components/tournaments/TournamentSquadList.svelte
+++ b/src/frontend/src/lib/components/tournaments/TournamentSquadList.svelte
@@ -44,8 +44,8 @@
     return true;
   }
 
-  function toggle_show_players(squad_id: number) {
-    squad_data[squad_id].display_players = !squad_data[squad_id].display_players;
+  function toggle_show_players(registration_id: number) {
+    squad_data[registration_id].display_players = !squad_data[registration_id].display_players;
   }
 
   function toggle_all_players() {
@@ -66,7 +66,7 @@
       return;
     }
     const payload = {
-      squad_id: squad.id,
+      registration_id: squad.id,
     };
     console.log(payload);
     const endpoint = `/api/tournaments/${tournament.id}/forceUnregisterSquad`;

--- a/src/frontend/src/lib/components/tournaments/placements/PlacementItem.svelte
+++ b/src/frontend/src/lib/components/tournaments/placements/PlacementItem.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
-    import Flag from "$lib/components/common/Flag.svelte";
     import type { PlacementOrganizer } from "$lib/types/placement-organizer";
     import SquadPlacementDisplay from "./SquadPlacementDisplay.svelte";
-    import { page } from "$app/stores";
     import { createEventDispatcher } from "svelte";
     import Dropdown from "$lib/components/common/Dropdown.svelte";
     import DropdownItem from "$lib/components/common/DropdownItem.svelte";
@@ -12,7 +10,6 @@
     const dispatch = createEventDispatcher();
 
     export let placement: PlacementOrganizer;
-    export let is_squad: boolean;
     export let is_edit: boolean;
     export let is_homepage = false;
 
@@ -77,14 +74,7 @@
         {getPlacementText(placement)}
     </div>
     <div class="info">
-        {#if !is_squad && placement.player}
-            <a href="/{$page.params.lang}/registry/players/profile?id={placement.player.player_id}">
-                <Flag country_code={placement.player.country_code} size="small"/>
-                {placement.player.name}
-            </a>
-        {:else if is_squad && placement.squad}
-            <SquadPlacementDisplay squad={placement.squad}/>
-        {/if}
+        <SquadPlacementDisplay squad={placement.squad}/>
     </div>
     {#if is_edit}
         <div class="actions">

--- a/src/frontend/src/lib/components/tournaments/placements/PlacementsDisplay.svelte
+++ b/src/frontend/src/lib/components/tournaments/placements/PlacementsDisplay.svelte
@@ -41,7 +41,7 @@
             {/if}
         </div>
         {#each show_all ? placement_list : placement_list.slice(0, num_display) as placement}
-            <PlacementItem {placement} is_squad={tournament.is_squad} is_edit={false}/>
+            <PlacementItem {placement} is_edit={false}/>
         {/each}
     </Section>
 {/if}

--- a/src/frontend/src/lib/components/tournaments/placements/PlacementsDragDropZone.svelte
+++ b/src/frontend/src/lib/components/tournaments/placements/PlacementsDragDropZone.svelte
@@ -8,7 +8,6 @@
     import LL from "$i18n/i18n-svelte";
 
     export let tournament_id: number;
-    export let is_squad: boolean;
     export let placements: TournamentPlacement[];
     export let is_placements = true;
 
@@ -166,7 +165,7 @@
 
 <section class="zone" use:dndzone={{items: placement_list}} on:consider={e => handleSort(e)} on:finalize={e => handleSort(e)}>
     {#each placement_list as p(p.id)}
-        <PlacementItem placement={p} {is_squad} is_edit={true} on:change={updatePlacements} on:dq={handleDQ}/>
+        <PlacementItem placement={p} is_edit={true} on:change={updatePlacements} on:dq={handleDQ}/>
     {/each}
     
 </section>

--- a/src/frontend/src/lib/components/tournaments/placements/SquadPlacementDisplay.svelte
+++ b/src/frontend/src/lib/components/tournaments/placements/SquadPlacementDisplay.svelte
@@ -8,9 +8,11 @@
 </script>
 
 <div class="flex">
-    <div>
-        <TagBadge tag={squad.tag} color={squad.color}/>
-    </div>
+    {#if squad.tag || squad.players.length > 4}
+        <div>
+            <TagBadge tag={squad.tag} color={squad.color}/>
+        </div>
+    {/if}
     
     {#if squad.name}
         <div>

--- a/src/frontend/src/lib/components/tournaments/registration/AddPlayerToSquad.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/AddPlayerToSquad.svelte
@@ -37,7 +37,7 @@
             selected_fc_id: selected_fc_id ? Number(selected_fc_id) : null,
             mii_name: mii_name,
             can_host: can_host === 'true',
-            squad_id: squad.id,
+            registration_id: squad.id,
             player_id: player.id,
             is_squad_captain: is_squad_captain === "true",
             is_representative: is_representative === "true",

--- a/src/frontend/src/lib/components/tournaments/registration/EditPlayerRegistration.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/EditPlayerRegistration.svelte
@@ -33,7 +33,7 @@
             selected_fc_id: selected_fc_id ? Number(selected_fc_id) : null,
             mii_name: mii_name,
             can_host: can_host === 'true',
-            squad_id: player.squad_id,
+            registration_id: player.registration_id,
             player_id: player.player_id,
             is_squad_captain: is_squad_captain !== null ? is_squad_captain === "true" : null,
             is_invite: Boolean(player.is_invite),
@@ -66,7 +66,7 @@
             selected_fc_id: selected_fc_id ? Number(selected_fc_id) : null,
             mii_name: mii_name,
             can_host: can_host === 'true',
-            squad_id: player.squad_id,
+            registration_id: player.registration_id,
         };
         const endpoint = `/api/tournaments/${tournament.id}/editMyRegistration`;
         console.log(payload);

--- a/src/frontend/src/lib/components/tournaments/registration/EditSquadDialog.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/EditSquadDialog.svelte
@@ -24,7 +24,7 @@
         let squad_tag = formData.get('squad_tag');
         let is_approved = formData.get('is_approved');
         const payload = {
-            squad_id: squad.id,
+            registration_id: squad.id,
             squad_color: Number(squad_color),
             squad_name: squad_name,
             squad_tag: squad_tag,
@@ -50,7 +50,7 @@
         let squad_name = formData.get('squad_name');
         let squad_tag = formData.get('squad_tag');
         const payload = {
-            squad_id: squad.id,
+            registration_id: squad.id,
             squad_color: Number(squad_color),
             squad_name: squad_name,
             squad_tag: squad_tag,

--- a/src/frontend/src/lib/components/tournaments/registration/ManageSquadRosters.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/ManageSquadRosters.svelte
@@ -42,7 +42,7 @@
         let conf = window.confirm($LL.TOURNAMENTS.REGISTRATIONS.ADD_ROSTER_CONFIRM({roster_name: roster.name}));
         if(!conf) return;
             const payload = {
-            squad_id: squad.id,
+            registration_id: squad.id,
             roster_id: roster.id
         }
         const endpoint = is_privileged ? `/api/tournaments/${tournament.id}/forceAddRosterToSquad` : `/api/tournaments/${tournament.id}/addRosterToSquad`;
@@ -63,7 +63,7 @@
         let conf = window.confirm($LL.TOURNAMENTS.REGISTRATIONS.REMOVE_ROSTER_CONFIRM({roster_name: String(roster.roster_name)}));
         if(!conf) return;
             const payload = {
-            squad_id: squad.id,
+            registration_id: squad.id,
             roster_id: roster.roster_id
         }
         const endpoint = is_privileged ? `/api/tournaments/${tournament.id}/forceRemoveRosterFromSquad` : `/api/tournaments/${tournament.id}/removeRosterFromSquad`;

--- a/src/frontend/src/lib/components/tournaments/registration/MyRegistration.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/MyRegistration.svelte
@@ -3,7 +3,6 @@
   import type { Tournament } from '$lib/types/tournament';
   import TournamentInviteList from './TournamentInviteList.svelte';
   import MySquad from './MySquad.svelte';
-  import TournamentPlayerList from '../TournamentPlayerList.svelte';
   import Button from '$lib/components/common/buttons/Button.svelte';
   import { BadgeCheckSolid } from 'flowbite-svelte-icons';
   import LL from '$i18n/i18n-svelte';
@@ -85,12 +84,7 @@
         {$LL.TOURNAMENTS.REGISTRATIONS.REGISTRATION_PENDING_MESSAGE()}
       </div>
     {/if}
-    {#if reg.squad}
-      <MySquad {tournament} squad={reg.squad} my_player={reg.player}/>
-    {:else}
-      <div>{$LL.TOURNAMENTS.REGISTRATIONS.MY_REGISTRATION()}</div>
-      <TournamentPlayerList {tournament} players={[reg.player]} my_player={reg.player}/>
-    {/if}
+    <MySquad {tournament} squad={reg.squad} my_player={reg.player}/>
   </div>
 {/each}
 

--- a/src/frontend/src/lib/components/tournaments/registration/MyRegistration.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/MyRegistration.svelte
@@ -77,7 +77,7 @@
         {/if}
       </div>
     {/if}
-    {#if tournament.verification_required && (!reg.squad.is_approved) || (reg.player && !reg.player.is_approved)}
+    {#if tournament.verification_required && ((!reg.squad.is_approved) || (reg.player && !reg.player.is_approved))}
       <div class="section">
         <div class="pending">
           {$LL.TOURNAMENTS.REGISTRATIONS.REGISTRATION_PENDING_APPROVAL()}

--- a/src/frontend/src/lib/components/tournaments/registration/MyRegistration.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/MyRegistration.svelte
@@ -20,7 +20,7 @@
   async function toggleCheckin(reg: RegistrationDetails) {
     const payload = {
       tournament_id: tournament.id,
-      squad_id: reg.player.squad_id,
+      registration_id: reg.player.registration_id,
       player_id: reg.player.player_id
     }
     const endpoint = `/api/tournaments/${tournament.id}/toggleCheckin`;

--- a/src/frontend/src/lib/components/tournaments/registration/MySquad.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/MySquad.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { TournamentSquad } from '$lib/types/tournament-squad';
+  import type { RegistrationDetails } from '$lib/types/tournaments/my-tournament-registration';
   import type { Tournament } from '$lib/types/tournament';
   import PlayerSearch from '$lib/components/common/PlayerSearch.svelte';
   import type { PlayerInfo } from '$lib/types/player-info';
@@ -12,14 +12,12 @@
   import type { UserInfo } from '$lib/types/user-info';
   import { user } from '$lib/stores/stores';
   import TournamentPlayerList from '../TournamentPlayerList.svelte';
-  import type { TournamentPlayer } from '$lib/types/tournament-player';
   import LL from '$i18n/i18n-svelte';
   import ManageSquadRosters from './ManageSquadRosters.svelte';
   import { game_fc_types } from '$lib/util/util';
 
   export let tournament: Tournament;
-  export let squad: TournamentSquad;
-  export let my_player: TournamentPlayer;
+  export let registration: RegistrationDetails;
 
   let edit_squad_dialog: Dialog;
   let manage_rosters_dialog: ManageSquadRosters;
@@ -27,8 +25,8 @@
   let invite_player: PlayerInfo | null = null;
   let invite_as_bagger = false;
 
-  let registered_players = squad.players.filter((p) => !p.is_invite);
-  let invited_players = squad.players.filter((p) => p.is_invite);
+  let registered_players = registration.squad.players.filter((p) => !p.is_invite);
+  let invited_players = registration.squad.players.filter((p) => p.is_invite);
 
   let user_info: UserInfo;
   user.subscribe((value) => {
@@ -40,17 +38,16 @@
       return;
     }
 
-    if (!my_player.is_squad_captain) {
+    if (!registration.is_squad_captain) {
       return;
     }
     const payload = {
-      registration_id: my_player.registration_id,
+      registration_id: registration.squad.id,
       player_id: player.id,
       is_representative: false,
       is_bagger_clause: invite_as_bagger
     };
     const endpoint = `/api/tournaments/${tournament.id}/invitePlayer`;
-    console.log(payload);
     const response = await fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -65,7 +62,7 @@
   }
 
   async function unregisterSquad() {
-    if (!my_player.is_squad_captain) {
+    if (!registration.is_squad_captain) {
       return;
     }
     let conf = window.confirm($LL.TOURNAMENTS.REGISTRATIONS.UNREGISTER_MY_SQUAD_CONFIRM());
@@ -73,9 +70,8 @@
       return;
     }
     const payload = {
-      registration_id: my_player.registration_id,
+      registration_id: registration.squad.id,
     };
-    console.log(payload);
     const endpoint = `/api/tournaments/${tournament.id}/unregisterSquad`;
     const response = await fetch(endpoint, {
       method: 'POST',
@@ -96,13 +92,12 @@
     let squad_name = formData.get('squad_name');
     let squad_tag = formData.get('squad_tag');
     const payload = {
-      registration_id: squad.id,
+      registration_id: registration.squad.id,
       squad_color: Number(squad_color),
       squad_name: squad_name,
       squad_tag: squad_tag,
     };
     const endpoint = `/api/tournaments/${tournament.id}/editMySquad`;
-    console.log(payload);
     const response = await fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -124,10 +119,10 @@
 {/if}
 <div>
   {#if tournament.squad_tag_required}
-    <TagBadge tag={squad.tag} color={squad.color}/>
+    <TagBadge tag={registration.squad.tag} color={registration.squad.color}/>
   {/if}
   {#if tournament.squad_name_required}
-    {squad.name}
+    {registration.squad.name}
   {/if}
 </div>
 {#if tournament.is_squad}
@@ -135,25 +130,25 @@
     {$LL.TOURNAMENTS.REGISTRATIONS.PLAYER_COUNT({count: registered_players.length})}
   </div>
 {/if}
-<TournamentPlayerList {tournament} players={registered_players} {my_player}/>
+<TournamentPlayerList {tournament} players={registered_players} {registration}/>
 
 {#if invited_players.length > 0}
   <div>
     {$LL.TOURNAMENTS.REGISTRATIONS.INVITED_PLAYER_COUNT({count: invited_players.length})}
   </div>
-  <TournamentPlayerList {tournament} players={invited_players} {my_player} exclude_invites={false}/>
+  <TournamentPlayerList {tournament} players={invited_players} {registration} exclude_invites={false}/>
 {/if}
 
-{#if check_registrations_open(tournament) && my_player.is_squad_captain}
+{#if check_registrations_open(tournament) && registration.is_squad_captain}
   <!-- If registrations are open and our squad is not full and we are the squad captain -->
   {#if check_tournament_permission(user_info, tournament_permissions.register_tournament, tournament.id, tournament.series_id, true) &&
-    (!tournament.max_squad_size || squad.players.length < tournament.max_squad_size)}
+    (!tournament.max_squad_size || registration.squad.players.length < tournament.max_squad_size)}
     <div>
       <div><b>{$LL.TOURNAMENTS.REGISTRATIONS.INVITE_PLAYERS()}</b></div>
       <PlayerSearch
         bind:player={invite_player}
         fc_type={game_fc_types[tournament.game]}
-        registration_id={tournament.team_members_only ? my_player.registration_id : null}
+        registration_id={tournament.team_members_only ? registration.squad.id : null}
       />
     </div>
     {#if invite_player}
@@ -180,14 +175,14 @@
     {/if}
     <Button on:click={unregisterSquad}>{$LL.TOURNAMENTS.REGISTRATIONS.UNREGISTER_SQUAD()}</Button>
     {#if tournament.teams_allowed}
-      <Button on:click={() => manage_rosters_dialog.open(squad)}>{$LL.TOURNAMENTS.REGISTRATIONS.MANAGE_ROSTERS()}</Button>
+      <Button on:click={() => manage_rosters_dialog.open(registration.squad)}>{$LL.TOURNAMENTS.REGISTRATIONS.MANAGE_ROSTERS()}</Button>
     {/if}
   </div>
 {/if}
 
 <Dialog bind:this={edit_squad_dialog} header={$LL.TOURNAMENTS.REGISTRATIONS.EDIT_SQUAD_REGISTRATION()}>
   <form method="POST" on:submit|preventDefault={editSquad}>
-    <SquadTournamentFields {tournament} squad_color={squad.color} squad_name={squad.name} squad_tag={squad.tag} />
+    <SquadTournamentFields {tournament} squad_color={registration.squad.color} squad_name={registration.squad.name} squad_tag={registration.squad.tag} />
     <br />
     <div>
       <Button type="submit">{$LL.TOURNAMENTS.REGISTRATIONS.EDIT_SQUAD()}</Button>

--- a/src/frontend/src/lib/components/tournaments/registration/MySquad.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/MySquad.svelte
@@ -117,7 +117,11 @@
   }
 </script>
 
-<div>{$LL.TOURNAMENTS.REGISTRATIONS.MY_SQUAD()}</div>
+{#if tournament.is_squad}
+  <div>{$LL.TOURNAMENTS.REGISTRATIONS.MY_SQUAD()}</div>
+{:else}
+  <div>{$LL.TOURNAMENTS.REGISTRATIONS.MY_REGISTRATION()}</div>
+{/if}
 <div>
   {#if tournament.squad_tag_required}
     <TagBadge tag={squad.tag} color={squad.color}/>
@@ -126,9 +130,11 @@
     {squad.name}
   {/if}
 </div>
-<div>
-  {$LL.TOURNAMENTS.REGISTRATIONS.PLAYER_COUNT({count: registered_players.length})}
-</div>
+{#if tournament.is_squad}
+  <div>
+    {$LL.TOURNAMENTS.REGISTRATIONS.PLAYER_COUNT({count: registered_players.length})}
+  </div>
+{/if}
 <TournamentPlayerList {tournament} players={registered_players} {my_player}/>
 
 {#if invited_players.length > 0}

--- a/src/frontend/src/lib/components/tournaments/registration/MySquad.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/MySquad.svelte
@@ -44,7 +44,7 @@
       return;
     }
     const payload = {
-      squad_id: my_player.squad_id,
+      registration_id: my_player.registration_id,
       player_id: player.id,
       is_representative: false,
       is_bagger_clause: invite_as_bagger
@@ -73,7 +73,7 @@
       return;
     }
     const payload = {
-      squad_id: my_player.squad_id,
+      registration_id: my_player.registration_id,
     };
     console.log(payload);
     const endpoint = `/api/tournaments/${tournament.id}/unregisterSquad`;
@@ -96,7 +96,7 @@
     let squad_name = formData.get('squad_name');
     let squad_tag = formData.get('squad_tag');
     const payload = {
-      squad_id: squad.id,
+      registration_id: squad.id,
       squad_color: Number(squad_color),
       squad_name: squad_name,
       squad_tag: squad_tag,
@@ -147,7 +147,7 @@
       <PlayerSearch
         bind:player={invite_player}
         fc_type={game_fc_types[tournament.game]}
-        squad_id={tournament.team_members_only ? my_player.squad_id : null}
+        registration_id={tournament.team_members_only ? my_player.registration_id : null}
       />
     </div>
     {#if invite_player}

--- a/src/frontend/src/lib/components/tournaments/registration/TournamentInviteList.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/TournamentInviteList.svelte
@@ -31,8 +31,8 @@
     squad_data[squad.id] = { display_players: false, date: new Date(squad.timestamp * 1000) };
   }
 
-  function toggle_show_players(squad_id: number) {
-    squad_data[squad_id].display_players = !squad_data[squad_id].display_players;
+  function toggle_show_players(registration_id: number) {
+    squad_data[registration_id].display_players = !squad_data[registration_id].display_players;
   }
 
   function toggle_all_players() {
@@ -59,7 +59,7 @@
       selected_fc_id: selected_fc_id ? Number(selected_fc_id) : null,
       mii_name: mii_name,
       can_host: can_host === 'true',
-      squad_id: curr_invite.id,
+      registration_id: curr_invite.id,
     };
     const endpoint = `/api/tournaments/${tournament.id}/acceptInvite`;
     console.log(payload);
@@ -83,7 +83,7 @@
       return;
     }
     const payload = {
-      squad_id: squad.id,
+      registration_id: squad.id,
     };
     const endpoint = `/api/tournaments/${tournament.id}/declineInvite`;
     console.log(payload);

--- a/src/frontend/src/lib/components/tournaments/registration/TournamentRegisterPanel.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/TournamentRegisterPanel.svelte
@@ -75,7 +75,7 @@
         {#if tournament.teams_allowed}
           <TeamTournamentRegister {tournament}/>
         {/if}
-        {#if !tournament.teams_only && !registration.registrations.some((r) => !r.player.is_invite)}
+        {#if !tournament.teams_only && !registration.registrations.some((r) => !r.is_invite)}
           {#if get_game_fcs(tournament.game, user_info.player.friend_codes).length}
             <div>{$LL.TOURNAMENTS.REGISTRATIONS.REGISTER_PROMPT()}</div>
             <SoloSquadTournamentRegister

--- a/src/frontend/src/lib/types/placement-organizer.ts
+++ b/src/frontend/src/lib/types/placement-organizer.ts
@@ -10,5 +10,5 @@ export type PlacementOrganizer = {
   placement_lower_bound: number | null;
   is_disqualified: boolean;
   player: TournamentPlayer | null;
-  squad: TournamentSquad | null;
+  squad: TournamentSquad;
 };

--- a/src/frontend/src/lib/types/tournament-placement.ts
+++ b/src/frontend/src/lib/types/tournament-placement.ts
@@ -19,12 +19,11 @@ export type TournamentPlacementSimplePlayerIDs = {
 
 export type TournamentPlacement = TournamentPlacementSimple & {
   player: TournamentPlayer | null;
-  squad: TournamentSquad | null;
+  squad: TournamentSquad;
 };
 
 export type TournamentPlacementList = {
   tournament_id: number;
-  is_squad: boolean;
   placements: TournamentPlacement[];
   unplaced: TournamentPlacement[];
 };

--- a/src/frontend/src/lib/types/tournament-placement.ts
+++ b/src/frontend/src/lib/types/tournament-placement.ts
@@ -34,7 +34,7 @@ export type PlayerTournamentPlacement = {
   tournament_name: string;
   game: string;
   mode: string;
-  squad_id: number | null;
+  registration_id: number | null;
   squad_name: string | null;
   team_id: number | null;
   date_start: number;

--- a/src/frontend/src/lib/types/tournament-player.ts
+++ b/src/frontend/src/lib/types/tournament-player.ts
@@ -4,7 +4,7 @@ import type { Discord } from './discord';
 export type TournamentPlayer = {
   id: number;
   player_id: number;
-  squad_id: number | null;
+  registration_id: number | null;
   timestamp: number;
   is_checked_in: boolean;
   is_approved: boolean;
@@ -24,5 +24,5 @@ export type TournamentPlayer = {
 export type TournamentPlayerDetailsShort = {
   player_id: number;
   player_name: string;
-  squad_id: number;
+  registration_id: number;
 };

--- a/src/frontend/src/lib/types/tournaments/my-tournament-registration.ts
+++ b/src/frontend/src/lib/types/tournaments/my-tournament-registration.ts
@@ -2,7 +2,7 @@ import type { TournamentSquad } from '../tournament-squad';
 import type { TournamentPlayer } from '../tournament-player';
 
 export type RegistrationDetails = {
-  squad: TournamentSquad | null;
+  squad: TournamentSquad;
   player: TournamentPlayer;
 };
 

--- a/src/frontend/src/lib/types/tournaments/my-tournament-registration.ts
+++ b/src/frontend/src/lib/types/tournaments/my-tournament-registration.ts
@@ -3,7 +3,9 @@ import type { TournamentPlayer } from '../tournament-player';
 
 export type RegistrationDetails = {
   squad: TournamentSquad;
-  player: TournamentPlayer;
+  player: TournamentPlayer | null;
+  is_squad_captain: boolean;
+  is_invite: boolean;
 };
 
 export type MyTournamentRegistration = {

--- a/src/frontend/src/routes/[lang]/tournaments/edit/+page.svelte
+++ b/src/frontend/src/routes/[lang]/tournaments/edit/+page.svelte
@@ -24,7 +24,51 @@
     if (res.status === 200) {
       const body: Tournament = await res.json();
       tournament = body;
-      data = {...body, logo_file: null, remove_logo: false,};
+      data = {
+        name: tournament.name,
+        series_id: tournament.series_id,
+        date_start: tournament.date_start,
+        date_end: tournament.date_end,
+        logo: tournament.logo,
+        use_series_logo: tournament.use_series_logo,
+        url: tournament.url,
+        organizer: tournament.organizer,
+        location: tournament.location,
+        game: tournament.game,
+        mode: tournament.mode,
+        is_squad: tournament.is_squad,
+        min_squad_size: tournament.min_squad_size,
+        max_squad_size: tournament.max_squad_size,
+        squad_name_required: tournament.squad_name_required,
+        squad_tag_required: tournament.squad_tag_required,
+        teams_allowed: tournament.teams_allowed,
+        teams_only: tournament.teams_only,
+        team_members_only: tournament.team_members_only,
+        min_representatives: tournament.min_representatives,
+        host_status_required: tournament.host_status_required,
+        mii_name_required: tournament.mii_name_required,
+        require_single_fc: tournament.require_single_fc,
+        checkins_enabled: tournament.checkins_enabled,
+        checkins_open: tournament.checkins_open,
+        min_players_checkin: tournament.min_players_checkin,
+        verification_required: tournament.verification_required,
+        description: tournament.description,
+        use_series_description: tournament.use_series_description,
+        ruleset: tournament.ruleset,
+        use_series_ruleset: tournament.use_series_ruleset,
+        registrations_open: tournament.registrations_open,
+        registration_deadline: tournament.registration_deadline,
+        registration_cap: tournament.registration_cap,
+        is_viewable: tournament.is_viewable,
+        is_public: tournament.is_public,
+        is_deleted: tournament.is_deleted,
+        show_on_profiles: tournament.show_on_profiles,
+        series_stats_include: tournament.series_stats_include,
+        verified_fc_required: tournament.verified_fc_required,
+        bagger_clause_enabled: tournament.bagger_clause_enabled,
+        logo_file: null,
+        remove_logo: false,
+      };
     }
   });
 </script>

--- a/src/frontend/src/routes/[lang]/tournaments/edit_placements/+page.svelte
+++ b/src/frontend/src/routes/[lang]/tournaments/edit_placements/+page.svelte
@@ -31,13 +31,11 @@
     <Section header={$LL.TOURNAMENTS.PLACEMENTS.EDIT_PLACEMENTS()}>
         <div slot="header_content">
             <Button href="/{$page.params.lang}/tournaments/edit_placements/raw?id={placements.tournament_id}">{$LL.TOURNAMENTS.PLACEMENTS.SWITCH_TO_RAW_INPUT()}</Button>
-            {#if placements.is_squad}
-                <Button href="/{$page.params.lang}/tournaments/edit_placements/raw_player_id?id={id}">{$LL.TOURNAMENTS.PLACEMENTS.RAW_INPUT_PLAYER_ID()}</Button>
-            {/if}
+            <Button href="/{$page.params.lang}/tournaments/edit_placements/raw_player_id?id={id}">{$LL.TOURNAMENTS.PLACEMENTS.RAW_INPUT_PLAYER_ID()}</Button>
         </div>
-        <PlacementsDragDropZone tournament_id={placements.tournament_id} is_squad={placements.is_squad} placements={placements.placements}/>
+        <PlacementsDragDropZone tournament_id={placements.tournament_id} placements={placements.placements}/>
     </Section>
-    <Section header={$LL.TOURNAMENTS.PLACEMENTS.UNPLACED({is_squad: placements.is_squad})}>
-        <PlacementsDragDropZone tournament_id={placements.tournament_id} is_squad={placements.is_squad} placements={placements.unplaced} is_placements={false}/>
+    <Section header={$LL.TOURNAMENTS.PLACEMENTS.UNPLACED({is_squad: true})}>
+        <PlacementsDragDropZone tournament_id={placements.tournament_id} placements={placements.unplaced} is_placements={false}/>
     </Section>
 {/if}

--- a/src/frontend/src/routes/[lang]/tournaments/edit_placements/raw/+page.svelte
+++ b/src/frontend/src/routes/[lang]/tournaments/edit_placements/raw/+page.svelte
@@ -113,9 +113,7 @@
     <Section header={$LL.TOURNAMENTS.PLACEMENTS.EDIT_PLACEMENTS()}>
         <div slot="header_content">
             <Button href="/{$page.params.lang}/tournaments/edit_placements?id={id}">{$LL.TOURNAMENTS.PLACEMENTS.SWITCH_TO_INTERACTIVE_INPUT()}</Button>
-            {#if placements.is_squad}
-                <Button href="/{$page.params.lang}/tournaments/edit_placements/raw_player_id?id={id}">{$LL.TOURNAMENTS.PLACEMENTS.RAW_INPUT_PLAYER_ID()}</Button>
-            {/if}
+            <Button href="/{$page.params.lang}/tournaments/edit_placements/raw_player_id?id={id}">{$LL.TOURNAMENTS.PLACEMENTS.RAW_INPUT_PLAYER_ID()}</Button>
         </div>
         <div>
             {$LL.TOURNAMENTS.PLACEMENTS.RAW_INPUT_INSTRUCTIONS()}


### PR DESCRIPTION
I had the realization that tournament squads and tournament players being used for separate situations causes a lot of repeated code (for example, there are two tournament placement tables for solo and squads, there were two commands to check tournament registrations as well as a player's own registration, etc.). If we add more features that depend on tournament registrations in the future, we will have to take into account both squads and players being used; for example, if we end up running FFA tournaments entirely on the site, we'd have to probably write two separate db tables for determining advancements among other things.

My solution to this was to rename the `tournament_squads` table to `tournament_registrations`. This new `tournament_registrations` table will be used for **all** tournaments, including solo tournaments. This means that all tournament players will have a linked tournament registration, instead of having no linked registration for solo tournaments. Most of these changes were purely on the backend so the UI doesn't change at all with these changes. With this change, I was able to:
- Merge the two tournament registration list commands into one command
- Merge `tournament_solo_placements` and `tournament_squad_placements` into `tournament_placements`
- Delete all commands which use `tournament_solo_placements`
- Merge the two "my registration" commands into one command
- Remove a bunch of checks to see if a tournament is a squad tournament in various API endpoints

These changes aren't entirely necessary for the site to function currently, but with the site's launch coming up soon it will be much harder to do them after we have launched the site. We can simply just delete and recreate the database on the beta site and re-import the old MKC data, so I wanted to get this merged in sooner rather than later.