### PR TITLE
Add Show Password Checkbox

### DIFF
--- a/src/frontend/src/lib/components/login/LoginRegister.svelte
+++ b/src/frontend/src/lib/components/login/LoginRegister.svelte
@@ -13,6 +13,11 @@
 
     let email = "";
     let password = "";
+    let show_password = false;
+
+    const togglePasswordVisibility = () => {
+        show_password = !show_password
+    }
 
     async function loginOrSignup(isLogin: boolean) {
         working = true;
@@ -85,7 +90,17 @@
                     <span class="item-label">
                         <label for="password">{$LL.LOGIN.PASSWORD()}</label>
                     </span>
-                    <input name="password" type="password" required bind:value={password} maxlength=64/>
+                    {#if show_password}
+                        <input name="password" type="text" required bind:value={password} maxlength=64/>
+                    {:else}
+                        <input name="password" type="password" required bind:value={password} maxlength=64/>
+                    {/if}
+                </div>
+                <div class="option">
+                    <span class="item-label">
+                        <label for="show-password">Show Password</label>
+                    </span>
+                    <input type="checkbox" on:click={togglePasswordVisibility} />
                 </div>
                 <div class="login-row">
                     <Button extra_classes="login-btn" type="submit" {working}>{$LL.LOGIN.LOGIN()}</Button>

--- a/src/frontend/src/lib/components/login/RegisterForm.svelte
+++ b/src/frontend/src/lib/components/login/RegisterForm.svelte
@@ -13,8 +13,13 @@
     const min_length = 8;
 
     let confirm_password = "";
+    let show_password = false;
     let agree_terms = false;
     let agree_policy = false;
+
+    const togglePasswordVisibility = () => {
+        show_password = !show_password
+    }
 
     $: button_disabled = password.length < 8 || password != confirm_password || (!is_change && !is_reset && (!agree_terms || !agree_policy));
 </script>
@@ -49,13 +54,27 @@
                     {/if}
                 </label>
             </span>
-            <input name="password" type="password" minlength={min_length} maxlength=64 bind:value={password} required/>
+            {#if show_password}
+                <input name="password" type="text" minlength={min_length} maxlength=64 bind:value={password} required/>
+            {:else}
+                <input name="password" type="password" minlength={min_length} maxlength=64 bind:value={password} required/>
+            {/if}
         </div>
         <div class="option">
             <span class="item-label">
                 <label for="confirm-password">{$LL.LOGIN.CONFIRM_PASSWORD()}</label>
             </span>
-            <input name="confirm-password" type="password" minlength={min_length} maxlength=64 bind:value={confirm_password} required/>
+            {#if show_password}
+                <input name="confirm-password" type="text" minlength={min_length} maxlength=64 bind:value={confirm_password} required/>
+            {:else}
+                <input name="confirm-password" type="password" minlength={min_length} maxlength=64 bind:value={confirm_password} required/>
+            {/if}
+        </div>
+        <div class="option">
+            <span class="item-label">
+                <label for="show-password">Show Password</label>
+            </span>
+            <input type="checkbox" on:click={togglePasswordVisibility} />
         </div>
         {#if !is_change && !is_reset}
             <div class="option">
@@ -131,5 +150,13 @@
     }
     .terms-label {
         text-decoration: underline;
+    }
+    .show-password-button {
+        font-size: 10pt;
+        padding: 8px;
+        border-radius: 5px;
+    }
+    .show-password-button:hover {
+        background-color: #256046;
     }
 </style>


### PR DESCRIPTION
<h1>Added a "Show Password" checkbox on the Login and Register drop down.</h1>

<h3>Login drop down "Show Password" disabled</h3>
![Screenshot 2025-06-25 230242](https://github.com/user-attachments/assets/170a2f87-00a7-49c1-9e52-89c823fde290)

<h3>Login drop down "Show Password" enabled</h3>
![Screenshot 2025-06-25 230145](https://github.com/user-attachments/assets/4e511f04-37c6-476d-8656-7dab7abf8ac3)

<h3>Register drop down "Show Password" disabled</h3>
![Screenshot 2025-06-25 230602](https://github.com/user-attachments/assets/31d9ef7e-f107-4bc9-8485-f877cf15efdb)

<h3>Register drop down "Show Password" enabled</h3>
![Screenshot 2025-06-25 230611](https://github.com/user-attachments/assets/64c67ac3-a256-4212-bf23-02c5ce3762d3)

I feel as this feature will add increase the user experience for the website
