### PR TITLE
chore(frontend): wrap %sveltekit.body% inside div

### DIFF
--- a/src/frontend/src/app.html
+++ b/src/frontend/src/app.html
@@ -13,8 +13,6 @@
     %sveltekit.head%
   </head>
   <body data-sveltekit-reload>
-    <div style="display: contents;">
-      %sveltekit.body%
-    </div>
+    <div style="display: contents">%sveltekit.body%</div>
   </body>
 </html>


### PR DESCRIPTION
Fixes the following issue:

<img width="1269" height="115" alt="image" src="https://github.com/user-attachments/assets/a23d0459-6cd1-4eed-8075-6180ff7c3315" />
