### PR TITLE
chore(prettier): add prettier-plugin-svelte to .prettierrc

### DIFF
--- a/src/frontend/.prettierrc
+++ b/src/frontend/.prettierrc
@@ -3,5 +3,5 @@
   "singleQuote": true,
   "trailingComma": "all",
   "printWidth": 120,
-  "plugins": ["prettier-plugin-tailwindcss"]
+  "plugins": ["prettier-plugin-tailwindcss", "prettier-plugin-svelte"]
 }


### PR DESCRIPTION
`.svelte` files have previously been unchecked/unformatted with `npm run lint` and `npm run format`. Including `prettier-plugin-svelte` inside `.prettierrc` will allow for such.