### PR TITLE
Several small fixes / requested features

### DIFF
--- a/src/backend/api/endpoints/moderation.py
+++ b/src/backend/api/endpoints/moderation.py
@@ -33,7 +33,7 @@ async def list_alt_flags(request: Request, filter: AltFlagFilter) -> JSONRespons
 @bind_request_query(PlayerAltFlagRequestData)
 @require_permission(permissions.VIEW_ALT_FLAGS)
 async def view_player_alt_flags(request: Request, body: PlayerAltFlagRequestData) -> JSONResponse:
-    flags = await handle(ViewPlayerAltFlagsCommand(body.player_id))
+    flags = await handle(ViewPlayerAltFlagsCommand(body.player_id, body.exclude_fingerprints))
     return JSONResponse(flags)
 
 @require_permission(permissions.VIEW_USER_LOGINS)

--- a/src/backend/api/endpoints/player_registry.py
+++ b/src/backend/api/endpoints/player_registry.py
@@ -179,6 +179,13 @@ async def get_player_transfer_history(request: Request) -> JSONResponse:
     result = await handle(command)
     return JSONResponse(result)
 
+@require_permission(permissions.EDIT_PLAYER)
+async def toggle_transfer_item_visibility(request: Request) -> JSONResponse:
+    player_id = int(request.path_params['player_id'])
+    item_id = int(request.path_params['item_id'])
+    await handle(ToggleTransferHistoryItemVisibilityCommand(item_id, player_id))
+    return JSONResponse({})
+
 @bind_request_body(ClaimPlayerRequestData)
 @require_logged_in()
 async def claim_player(request: Request, body: ClaimPlayerRequestData) -> JSONResponse:
@@ -252,4 +259,5 @@ routes = [
     Route('/api/registry/players/denyClaim', deny_player_claim, methods=['POST']), # dispatches notification
     Route('/api/registry/players/claims', list_player_claims),
     Route('/api/registry/players/merge', merge_players, methods=['POST']),
+    Route('/api/registry/players/{player_id:int}/toggleTransferItemVisibility/{item_id:int}', toggle_transfer_item_visibility, methods=['POST']),
 ]

--- a/src/backend/common/data/commands/auth/roles.py
+++ b/src/backend/common/data/commands/auth/roles.py
@@ -328,6 +328,7 @@ class UpdateRoleExpirationCommand(Command[None]):
     target_player_id: int
     role: str
     expires_on: int | None = None
+    is_ban: bool = False
 
     async def handle(self, db_wrapper, s3_wrapper) -> None:
         async with db_wrapper.connect() as db:
@@ -352,7 +353,7 @@ class UpdateRoleExpirationCommand(Command[None]):
         
             # to have permission to grant a role, we should have a role which is both higher
             # in the role hierarchy than the role we wish to grant, and has the MANAGE_USER_ROLES
-            # permission.
+            # permission. if it's a ban, we don't need the MANAGE_USER_ROLES permission
             async with db.execute("""
                 SELECT EXISTS(
                     SELECT 1 FROM roles r1
@@ -360,10 +361,10 @@ class UpdateRoleExpirationCommand(Command[None]):
                     JOIN role_permissions rp ON ur.role_id = rp.role_id
                     JOIN permissions p ON rp.permission_id = p.id
                     JOIN roles r2
-                    WHERE ur.user_id = ? AND r2.name = ? AND r1.position < r2.position
-                    AND rp.is_denied = 0 AND p.name = ?
+                    WHERE ur.user_id = :granter_user_id AND r2.name = :role_name AND r1.position < r2.position
+                    AND rp.is_denied = 0 AND (:is_ban = 0 OR p.name = :permission_name)
                 )
-                """, (self.granter_user_id, self.role, permissions.MANAGE_USER_ROLES)) as cursor:
+                """, {'granter_user_id': self.granter_user_id, 'role_name': self.role, 'permission_name': permissions.MANAGE_USER_ROLES, 'is_ban': self.is_ban}) as cursor:
                 row = await cursor.fetchone()
                 can_grant = row is not None and bool(row[0])
 

--- a/src/backend/common/data/commands/moderation/alt_detection.py
+++ b/src/backend/common/data/commands/moderation/alt_detection.py
@@ -115,7 +115,7 @@ class ListAltFlagsCommand(Command[AltFlagList]):
 
             get_flags_query = """
                 SELECT f.id, f.type, f.flag_key, f.data, f.score, f.date, l.fingerprint,
-                       u.id as user_id, p.id as player_id, p.name as player_name, p.country_code
+                       u.id as user_id, p.id as player_id, p.name as player_name, p.country_code, p.is_banned
                 FROM (
                     SELECT id FROM alt_flags.alt_flags
                     WHERE (:type IS NULL OR type = :type)
@@ -135,7 +135,7 @@ class ListAltFlagsCommand(Command[AltFlagList]):
             async with db.execute(get_flags_query, {"limit": limit, "offset": offset, "type": self.filter.type,
                                                     "exclude_fingerprints": self.filter.exclude_fingerprints}) as cursor:
                 rows = await cursor.fetchall()
-                for flag_id, flag_type, flag_key, data, score, date, fingerprint_hash, user_id, player_id, player_name, player_country in rows:
+                for flag_id, flag_type, flag_key, data, score, date, fingerprint_hash, user_id, player_id, player_name, player_country, player_banned in rows:
                     # Create flag if we haven't seen it yet
                     if flag_id not in flag_dict:
                         flag_dict[flag_id] = AltFlag(flag_id, flag_type, flag_key, data, score, date, fingerprint_hash, [])
@@ -144,7 +144,7 @@ class ListAltFlagsCommand(Command[AltFlagList]):
                     if user_id is not None:
                         player = None
                         if player_id is not None:
-                            player = PlayerBasic(player_id, player_name, player_country)
+                            player = PlayerBasic(player_id, player_name, player_country, bool(player_banned))
                         flag_user = AltFlagUser(user_id, player)
                         flag_dict[flag_id].users.append(flag_user)
 
@@ -159,7 +159,7 @@ class ViewPlayerAltFlagsCommand(Command[list[AltFlag]]):
         async with db_wrapper.connect(db_name="main", attach=["user_activity", "alt_flags"], readonly=True) as db:
 
             get_user_player_info = """
-                SELECT u.id as user_id, p.id, p.name, p.country_code
+                SELECT u.id as user_id, p.id, p.name, p.country_code, p.is_banned
                 FROM main.users u
                 JOIN main.players p ON u.player_id = p.id
                 WHERE p.id = :player_id
@@ -168,8 +168,8 @@ class ViewPlayerAltFlagsCommand(Command[list[AltFlag]]):
                 row = await cursor.fetchone()
                 if not row:
                     raise Problem("Player not found", status=404)
-                user_id, player_id, player_name, player_country = row
-                current_player = PlayerBasic(player_id, player_name, player_country)
+                user_id, player_id, player_name, player_country, player_banned = row
+                current_player = PlayerBasic(player_id, player_name, player_country, bool(player_banned))
                 current_user = AltFlagUser(user_id, current_player)
                 
 
@@ -191,7 +191,7 @@ class ViewPlayerAltFlagsCommand(Command[list[AltFlag]]):
 
            # get other players with the same flags
             get_flag_players_command = """
-                SELECT u.id, p.id, p.name, p.country_code, uf2.flag_id
+                SELECT u.id, p.id, p.name, p.country_code, p.is_banned, uf2.flag_id
                 FROM alt_flags.user_alt_flags uf1
                 JOIN alt_flags.user_alt_flags uf2 ON uf1.flag_id = uf2.flag_id
                 JOIN main.users u ON uf2.user_id = u.id
@@ -202,12 +202,12 @@ class ViewPlayerAltFlagsCommand(Command[list[AltFlag]]):
             async with db.execute(get_flag_players_command, {"user_id": user_id}) as cursor:
                 rows = await cursor.fetchall()
                 for row in rows:
-                    user_id, player_id, player_name, player_country, flag_id = row
+                    user_id, player_id, player_name, player_country, player_banned, flag_id = row
                     flag = flag_dict.get(flag_id)
                     if flag:
                         current_player = None
                         if player_id:
-                            current_player = PlayerBasic(player_id, player_name, player_country)
+                            current_player = PlayerBasic(player_id, player_name, player_country, bool(player_banned))
                         flag.users.append(AltFlagUser(user_id, current_player))
             
             return list(flag_dict.values())
@@ -283,7 +283,7 @@ class ViewHistoryForIPCommand(Command[IPHistory]):
             async with db.execute("""SELECT ip.id, ip.ip_address, ip.is_mobile, ip.is_vpn,
                                     ip.country, ip.region, ip.city, ip.asn,
                                     uip.user_id, tr.id, tr.date_earliest,
-                                    tr.date_latest, tr.times, p.id, p.name, p.country_code
+                                    tr.date_latest, tr.times, p.id, p.name, p.country_code, p.is_banned
                                     FROM user_activity.ip_addresses ip
                                     JOIN user_activity.user_ips uip ON ip.id = uip.ip_address_id
                                     JOIN user_activity.user_ip_time_ranges tr ON uip.id = tr.user_ip_id
@@ -295,7 +295,7 @@ class ViewHistoryForIPCommand(Command[IPHistory]):
                 for row in rows:
                     (ip_id, ip_address, is_mobile, is_vpn, ip_country, ip_region, ip_city, ip_asn,
                         user_id, time_range_id,
-                        date_earliest, date_latest, times, player_id, player_name, player_country) = row
+                        date_earliest, date_latest, times, player_id, player_name, player_country, player_banned) = row
                     if not self.has_ip_permission:
                         ip_address = None
                         ip_city = None
@@ -303,7 +303,7 @@ class ViewHistoryForIPCommand(Command[IPHistory]):
                     ip_time_range = UserIPTimeRange(time_range_id, user_id, ip, date_earliest, date_latest, times)
                     player = None
                     if player_id:
-                        player = PlayerBasic(player_id, player_name, player_country)
+                        player = PlayerBasic(player_id, player_name, player_country, bool(player_banned))
                     player_time_range = PlayerIPTimeRange(ip_time_range, player)
                     time_ranges.append(player_time_range)
         ip_history = IPHistory(self.ip_id, time_ranges)

--- a/src/backend/common/data/commands/players/claims.py
+++ b/src/backend/common/data/commands/players/claims.py
@@ -87,8 +87,8 @@ class ListPlayerClaimsCommand(Command[list[PlayerClaim]]):
     async def handle(self, db_wrapper, s3_wrapper):
         async with db_wrapper.connect() as db:
             async with db.execute("""SELECT c.id, c.date, c.approval_status,
-                                  c.player_id, p1.name, p1.country_code, 
-                                  c.claimed_player_id, p2.name, p2.country_code
+                                  c.player_id, p1.name, p1.country_code, p1.is_banned,
+                                  c.claimed_player_id, p2.name, p2.country_code, p2.is_banned
                                   FROM player_claims c
                                   JOIN players p1 ON c.player_id = p1.id
                                   JOIN players p2 ON c.claimed_player_id = p2.id
@@ -96,9 +96,9 @@ class ListPlayerClaimsCommand(Command[list[PlayerClaim]]):
                 claims: list[PlayerClaim] = []
                 rows = await cursor.fetchall()
                 for row in rows:
-                    (claim_id, date, approval_status, player_id, player_name, player_country, 
-                     claim_player_id, claim_player_name, claim_player_country) = row
-                    player = PlayerBasic(player_id, player_name, player_country)
-                    claimed_player = PlayerBasic(claim_player_id, claim_player_name, claim_player_country)
+                    (claim_id, date, approval_status, player_id, player_name, player_country, player_banned, 
+                     claim_player_id, claim_player_name, claim_player_country, claim_player_banned) = row
+                    player = PlayerBasic(player_id, player_name, player_country, bool(player_banned))
+                    claimed_player = PlayerBasic(claim_player_id, claim_player_name, claim_player_country, bool(claim_player_banned))
                     claims.append(PlayerClaim(claim_id, date, approval_status, player, claimed_player))
         return claims

--- a/src/backend/common/data/commands/players/friend_codes.py
+++ b/src/backend/common/data/commands/players/friend_codes.py
@@ -141,20 +141,20 @@ class ListFriendCodeEditsCommand(Command[FriendCodeEditList]):
             edits: list[FriendCodeEdit] = []
             async with db.execute(f"""SELECT e.id, e.old_fc, e.new_fc, e.is_active, e.date,
                                         f.id, f.type, f.fc, f.is_verified, f.is_primary, f.is_active,
-                                        f.description, f.creation_date, p.id, p.name, p.country_code,
-                                        p2.id, p2.name, p2.country_code
+                                        f.description, f.creation_date, p.id, p.name, p.country_code, p.is_banned,
+                                        p2.id, p2.name, p2.country_code, p2.is_banned
                                         {edit_query} ORDER BY e.date DESC LIMIT ? OFFSET ?
                                   """, (limit, offset)) as cursor:
                 rows = await cursor.fetchall()
                 for row in rows:
                     (edit_id, old_fc, new_fc, edit_active, edit_date, fc_id, fc_type, fc_fc, is_verified, is_primary, is_active,
-                    description, creation_date, player_id, player_name, player_country, handled_by_id, handled_by_name, 
-                    handled_by_country) = row
-                    player = PlayerBasic(player_id, player_name, player_country)
+                    description, creation_date, player_id, player_name, player_country, player_banned, handled_by_id, handled_by_name, 
+                    handled_by_country, handled_by_banned) = row
+                    player = PlayerBasic(player_id, player_name, player_country, bool(player_banned))
                     fc = FriendCode(fc_id, fc_fc, fc_type, player_id, is_verified, is_primary, creation_date, description, is_active)
                     handled_by = None
                     if handled_by_id:
-                        handled_by = PlayerBasic(handled_by_id, handled_by_name, handled_by_country)
+                        handled_by = PlayerBasic(handled_by_id, handled_by_name, handled_by_country, bool(handled_by_banned))
                     edit = FriendCodeEdit(edit_id, old_fc, new_fc, edit_active, edit_date, fc, player, handled_by)
                     edits.append(edit)
         

--- a/src/backend/common/data/commands/players/name_changes.py
+++ b/src/backend/common/data/commands/players/name_changes.py
@@ -46,14 +46,15 @@ class ListPlayerNameRequestsCommand(Command[PlayerNameRequestList]):
                                 JOIN players p ON r.player_id = p.id
                                 LEFT JOIN players p2 ON r.handled_by = p2.id
                                 WHERE r.approval_status = ? ORDER BY r.date DESC"""
-            async with db.execute(f"""SELECT p.id, p.country_code, r.id, r.old_name, r.new_name, r.date, r.approval_status, r.handled_by, p2.name, p2.country_code
+            async with db.execute(f"""SELECT p.id, p.country_code, r.id, r.old_name, r.new_name, r.date, r.approval_status, r.handled_by, p2.name, p2.country_code, p2.is_banned
                                   {request_query} LIMIT ? OFFSET ?""", (filter.approval_status, limit, offset)) as cursor:
                 rows = await cursor.fetchall()
                 for row in rows:
-                    player_id, player_country, request_id, old_name, new_name, date, approval_status, handled_by_id, handled_by_name, handled_by_country = row
+                    (player_id, player_country, request_id, old_name, new_name, date, approval_status,
+                      handled_by_id, handled_by_name, handled_by_country, handled_by_banned) = row
                     handled_by = None
                     if handled_by_id:
-                        handled_by = PlayerBasic(handled_by_id, handled_by_name, handled_by_country)
+                        handled_by = PlayerBasic(handled_by_id, handled_by_name, handled_by_country, bool(handled_by_banned))
                     name_requests.append(PlayerNameRequest(request_id, player_id, player_country, old_name, new_name, date, approval_status, handled_by))
 
             count_query = f"SELECT COUNT(*) {request_query}"

--- a/src/backend/common/data/commands/teams/rosters.py
+++ b/src/backend/common/data/commands/teams/rosters.py
@@ -178,17 +178,30 @@ class LeaveRosterCommand(Command[None]):
             # players leaving a roster goes into the transfer history too
             await db.execute("""INSERT INTO team_transfers(player_id, roster_id, date, roster_leave_id, is_accepted, approval_status, is_bagger_clause)
                              VALUES (?, ?, ?, ?, ?, ?, ?)""", (self.player_id, None, leave_date, self.roster_id, True, "approved", False))
-            # get all team tournament rosters the player is in where the tournament hasn't ended yet
+            # get all team tournament rosters the player is in where registrations haven't closed yet
             async with db.execute("""SELECT p.registration_id FROM tournament_players p
                                 JOIN team_squad_registrations s ON p.registration_id = s.registration_id
                                 JOIN tournaments t ON p.tournament_id = t.id
                                 WHERE p.player_id = ? AND s.roster_id = ?
-                                AND (t.date_end > ? OR t.registrations_open = ?) AND t.team_members_only = ?""",
-                                (self.player_id, self.roster_id, leave_date, True, True)) as cursor:
+                                AND t.registrations_open = 1 AND t.team_members_only = 1""",
+                                (self.player_id, self.roster_id)) as cursor:
                 rows = await cursor.fetchall()
                 registration_ids: list[int] = [row[0] for row in rows]
             # finally remove the player from all the tournaments they shouldn't be in
             await db.execute(f"DELETE FROM tournament_players WHERE player_id = ? AND registration_id IN ({','.join(map(str, registration_ids))})", (self.player_id,))
+
+            # get all team tournament rosters the player is in where registrations have closed and they should be marked as ineligible
+            async with db.execute("""SELECT p.registration_id FROM tournament_players p
+                                JOIN team_squad_registrations s ON p.registration_id = s.registration_id
+                                JOIN tournaments t ON p.tournament_id = t.id
+                                WHERE p.player_id = ? AND s.roster_id = ?
+                                AND t.registrations_open = 0 AND t.team_members_only = 1
+                                AND t.sync_team_rosters = 1 AND t.date_end > ?""",
+                                (self.player_id, self.roster_id, leave_date)) as cursor:
+                rows = await cursor.fetchall()
+                registration_ids: list[int] = [row[0] for row in rows]
+            # finally mark the player as ineligible from any tournaments their old team was in
+            await db.execute(f"UPDATE tournament_players SET is_eligible = 0 WHERE player_id = ? AND registration_id IN ({','.join(map(str, registration_ids))})", (self.player_id,))
 
             # remove user's team roles if they are no longer in a roster for this team
             if user_id is not None:
@@ -579,17 +592,32 @@ class EditTeamMemberCommand(Command[None]):
                 await db.execute("""INSERT INTO team_transfers(player_id, roster_id, date, roster_leave_id, is_accepted, approval_status, is_bagger_clause)
                                     VALUES(?, ?, ?, ?, ?, ?, ?)""", (self.player_id, None, self.leave_date, self.roster_id, True, "approved", member_is_bagger))
 
-                # get all team tournament rosters the player is in where the tournament hasn't ended yet
+                # get all team tournament rosters the player is in where registrations haven't closed yet
                 async with db.execute("""SELECT p.registration_id FROM tournament_players p
                                     JOIN team_squad_registrations s ON p.registration_id = s.registration_id
                                     JOIN tournaments t ON p.tournament_id = t.id
                                     WHERE p.player_id = ? AND s.roster_id = ?
-                                    AND (t.date_end > ? OR t.registrations_open = ?) AND t.team_members_only = ?""",
-                                    (self.player_id, self.roster_id, self.leave_date, True, True)) as cursor:
+                                    AND t.registrations_open = 1 AND t.team_members_only = 1
+                                    AND p.is_bagger_clause = ?""",
+                                    (self.player_id, self.roster_id, self.is_bagger_clause)) as cursor:
                     rows = await cursor.fetchall()
                     registration_ids: list[int] = [row[0] for row in rows]
                 # finally remove the player from all the tournaments they shouldn't be in
                 await db.execute(f"DELETE FROM tournament_players WHERE player_id = ? AND registration_id IN ({','.join(map(str, registration_ids))})", (self.player_id,))
+
+                # get all team tournament rosters the player is in where registrations have closed and they should be marked as ineligible
+                async with db.execute("""SELECT p.registration_id FROM tournament_players p
+                                    JOIN team_squad_registrations s ON p.registration_id = s.registration_id
+                                    JOIN tournaments t ON p.tournament_id = t.id
+                                    WHERE p.player_id = ? AND s.roster_id = ?
+                                    AND t.registrations_open = 0 AND t.team_members_only = 1
+                                    AND t.sync_team_rosters = 1 AND t.date_end > ?
+                                    AND p.is_bagger_clause = ?""",
+                                    (self.player_id, self.roster_id, self.leave_date, self.is_bagger_clause)) as cursor:
+                    rows = await cursor.fetchall()
+                    registration_ids: list[int] = [row[0] for row in rows]
+                # finally mark the player as ineligible from any tournaments their old team was in
+                await db.execute(f"UPDATE tournament_players SET is_eligible = 0 WHERE player_id = ? AND registration_id IN ({','.join(map(str, registration_ids))})", (self.player_id,))
                     
                 # remove user's team roles if they are no longer in a roster for this team
                 if user_id is not None:

--- a/src/backend/common/data/commands/teams/transfers.py
+++ b/src/backend/common/data/commands/teams/transfers.py
@@ -60,14 +60,14 @@ class ApproveTransferCommand(Command[None]):
                 await db.executemany("UPDATE tournament_players SET is_bagger_clause = ? WHERE id = ?", bagger_registration_ids)
             if team_member_id:
                 await db.execute("UPDATE team_members SET leave_date = ? WHERE id = ?", (curr_time, team_member_id))
-                # get all team tournament rosters the player is in where the tournament hasn't ended yet
+                # get all team tournament rosters the player is in where registrations haven't closed yet
                 async with db.execute("""SELECT p.registration_id FROM tournament_players p
                                     JOIN team_squad_registrations s ON p.registration_id = s.registration_id
                                     JOIN tournaments t ON p.tournament_id = t.id
                                     WHERE p.player_id = ? AND s.roster_id = ?
-                                    AND (t.date_end > ? OR t.registrations_open = ?) AND t.team_members_only = ?
+                                    AND t.registrations_open = 1 AND t.team_members_only = 1
                                     AND p.is_bagger_clause = ?""",
-                                    (player_id, roster_leave_id, curr_time, True, True, is_bagger_clause)) as cursor:
+                                    (player_id, roster_leave_id, is_bagger_clause)) as cursor:
                     rows = await cursor.fetchall()
                     registration_ids: list[int] = [row[0] for row in rows]
                 # if any of these squads the player was in previously are also linked to the new roster,
@@ -76,15 +76,43 @@ class ApproveTransferCommand(Command[None]):
                                     JOIN team_squad_registrations s ON p.registration_id = s.registration_id
                                     JOIN tournaments t ON p.tournament_id = t.id
                                     WHERE p.player_id = ? AND s.roster_id = ?
-                                    AND (t.date_end > ? OR t.registrations_open = ?) AND t.team_members_only = ?
+                                    AND t.registrations_open = 1 AND t.team_members_only = 1
                                     AND p.is_bagger_clause = ?""",
-                                    (player_id, roster_id, curr_time, True, True, is_bagger_clause)) as cursor:
+                                    (player_id, roster_id, is_bagger_clause)) as cursor:
                     rows = await cursor.fetchall()
                     for row in rows:
                         if row[0] in registration_ids:
                             registration_ids.remove(row[0])
                 # finally remove the player from all the tournaments they shouldn't be in
                 await db.execute(f"DELETE FROM tournament_players WHERE player_id = ? AND registration_id IN ({','.join(map(str, registration_ids))})", (player_id,))
+
+                # get all team tournament rosters the player is in where registrations have closed and they should be marked as ineligible
+                async with db.execute("""SELECT p.registration_id FROM tournament_players p
+                                    JOIN team_squad_registrations s ON p.registration_id = s.registration_id
+                                    JOIN tournaments t ON p.tournament_id = t.id
+                                    WHERE p.player_id = ? AND s.roster_id = ?
+                                    AND t.registrations_open = 0 AND t.team_members_only = 1
+                                    AND t.sync_team_rosters = 1 AND t.date_end > ?
+                                    AND p.is_bagger_clause = ?""",
+                                    (player_id, roster_leave_id, curr_time, is_bagger_clause)) as cursor:
+                    rows = await cursor.fetchall()
+                    registration_ids: list[int] = [row[0] for row in rows]
+                # if any of these squads the player was in previously are also linked to the new roster,
+                # (such as when transferring between two rosters of same team), we don't want to mark them as ineligible
+                async with db.execute("""SELECT p.registration_id FROM tournament_players p
+                                    JOIN team_squad_registrations s ON p.registration_id = s.registration_id
+                                    JOIN tournaments t ON p.tournament_id = t.id
+                                    WHERE p.player_id = ? AND s.roster_id = ?
+                                    AND t.registrations_open = 0 AND t.team_members_only = 1
+                                    AND t.sync_team_rosters = 1 AND t.date_end > ?
+                                    AND p.is_bagger_clause = ?""",
+                                    (player_id, roster_id, curr_time, is_bagger_clause)) as cursor:
+                    rows = await cursor.fetchall()
+                    for row in rows:
+                        if row[0] in registration_ids:
+                            registration_ids.remove(row[0])
+                # finally mark the player as ineligible from any tournaments their old team was in
+                await db.execute(f"UPDATE tournament_players SET is_eligible = 0 WHERE player_id = ? AND registration_id IN ({','.join(map(str, registration_ids))})", (player_id,))
 
             # next we want to automatically add the transferred player to any team tournaments where that team is registered
             # and registrations are open
@@ -320,14 +348,14 @@ class ForceTransferPlayerCommand(Command[None]):
                              VALUES(?, ?, ?, ?, ?, ?, ?)""", (self.player_id, self.roster_id, curr_time, self.roster_leave_id, True, "approved", self.is_bagger_clause))
             if team_member_id:
                 await db.execute("UPDATE team_members SET leave_date = ? WHERE id = ?", (curr_time, team_member_id))
-                # get all team tournament rosters the player is in where the tournament hasn't ended yet
+                # get all team tournament rosters the player is in where registrations haven't closed yet
                 async with db.execute("""SELECT p.registration_id FROM tournament_players p
                                     JOIN team_squad_registrations s ON p.registration_id = s.registration_id
                                     JOIN tournaments t ON p.tournament_id = t.id
                                     WHERE p.player_id = ? AND s.roster_id = ?
-                                    AND (t.date_end > ? OR t.registrations_open = ?) AND t.team_members_only = ?
+                                    AND t.registrations_open = 1 AND t.team_members_only = 1
                                     AND p.is_bagger_clause = ?""",
-                                    (self.player_id, self.roster_leave_id, curr_time, True, True, self.is_bagger_clause)) as cursor:
+                                    (self.player_id, self.roster_leave_id, self.is_bagger_clause)) as cursor:
                     rows = await cursor.fetchall()
                     registration_ids: list[int] = [row[0] for row in rows]
                 # if any of these squads the player was in previously are also linked to the new roster,
@@ -336,15 +364,43 @@ class ForceTransferPlayerCommand(Command[None]):
                                     JOIN team_squad_registrations s ON p.registration_id = s.registration_id
                                     JOIN tournaments t ON p.tournament_id = t.id
                                     WHERE p.player_id = ? AND s.roster_id = ?
-                                    AND (t.date_end > ? OR t.registrations_open = ?) AND t.team_members_only = ?
+                                    AND t.registrations_open = 1 AND t.team_members_only = 1
                                     AND p.is_bagger_clause = ?""",
-                                    (self.player_id, self.roster_id, curr_time, True, True, self.is_bagger_clause)) as cursor:
+                                    (self.player_id, self.roster_id, self.is_bagger_clause)) as cursor:
                     rows = await cursor.fetchall()
                     for row in rows:
                         if row[0] in registration_ids:
                             registration_ids.remove(row[0])
                 # finally remove the player from all the tournaments they shouldn't be in
                 await db.execute(f"DELETE FROM tournament_players WHERE player_id = ? AND registration_id IN ({','.join(map(str, registration_ids))})", (self.player_id,))
+
+                # get all team tournament rosters the player is in where registrations have closed and they should be marked as ineligible
+                async with db.execute("""SELECT p.registration_id FROM tournament_players p
+                                    JOIN team_squad_registrations s ON p.registration_id = s.registration_id
+                                    JOIN tournaments t ON p.tournament_id = t.id
+                                    WHERE p.player_id = ? AND s.roster_id = ?
+                                    AND t.registrations_open = 0 AND t.team_members_only = 1
+                                    AND t.sync_team_rosters = 1 AND t.date_end > ?
+                                    AND p.is_bagger_clause = ?""",
+                                    (self.player_id, self.roster_leave_id, curr_time, self.is_bagger_clause)) as cursor:
+                    rows = await cursor.fetchall()
+                    registration_ids: list[int] = [row[0] for row in rows]
+                # if any of these squads the player was in previously are also linked to the new roster,
+                # (such as when transferring between two rosters of same team), we don't want to mark them as ineligible
+                async with db.execute("""SELECT p.registration_id FROM tournament_players p
+                                    JOIN team_squad_registrations s ON p.registration_id = s.registration_id
+                                    JOIN tournaments t ON p.tournament_id = t.id
+                                    WHERE p.player_id = ? AND s.roster_id = ?
+                                    AND t.registrations_open = 0 AND t.team_members_only = 1
+                                    AND t.sync_team_rosters = 1 AND t.date_end > ?
+                                    AND p.is_bagger_clause = ?""",
+                                    (self.player_id, self.roster_id, curr_time, self.is_bagger_clause)) as cursor:
+                    rows = await cursor.fetchall()
+                    for row in rows:
+                        if row[0] in registration_ids:
+                            registration_ids.remove(row[0])
+                # finally mark the player as ineligible from any tournaments their old team was in
+                await db.execute(f"UPDATE tournament_players SET is_eligible = 0 WHERE player_id = ? AND registration_id IN ({','.join(map(str, registration_ids))})", (self.player_id,))
 
             # next we want to automatically add the transferred player to any team tournaments where that team is registered
             # and registrations are open

--- a/src/backend/common/data/commands/tournaments/placements.py
+++ b/src/backend/common/data/commands/tournaments/placements.py
@@ -200,6 +200,7 @@ class GetPlayerTournamentPlacementsCommand(Command[PlayerTournamentResults]):
                 AND t.teams_allowed = 0
                 AND (t.min_squad_size IS NULL OR t.min_squad_size <= 4)
                 AND tp.player_id = ?
+                AND tp.is_invite = 0
                 AND s.is_registered = 1
                 """, (self.player_id,)) as cursor:
                 rows = await cursor.fetchall()

--- a/src/backend/common/data/commands/tournaments/registrations.py
+++ b/src/backend/common/data/commands/tournaments/registrations.py
@@ -579,3 +579,11 @@ class TogglePlayerCheckinCommand(Command[None]):
             await db.execute("UPDATE tournament_players SET is_checked_in = ? WHERE tournament_id = ? AND registration_id IS ? AND player_id = ?",
                                   (not is_checked_in, self.tournament_id, self.registration_id, self.player_id))
             await db.commit()
+
+@dataclass
+class CloseTournamentRegistrationsCommand(Command[None]):
+    async def handle(self, db_wrapper, s3_wrapper):
+        async with db_wrapper.connect() as db:
+            now = int(datetime.now(timezone.utc).timestamp())
+            await db.execute("UPDATE tournaments SET registrations_open = 0 WHERE registrations_open = 1 AND registration_deadline > ?", (now,))
+            await db.commit()

--- a/src/backend/common/data/commands/tournaments/registrations.py
+++ b/src/backend/common/data/commands/tournaments/registrations.py
@@ -355,7 +355,7 @@ class GetTournamentRegistrationsCommand(Command[list[TournamentSquadDetails]]):
             # get tournament players
             async with db.execute("""SELECT t.id, t.player_id, t.registration_id, t.is_squad_captain, t.is_representative, t.timestamp, t.is_checked_in, 
                                     t.mii_name, t.can_host, t.is_invite, t.selected_fc_id, t.is_bagger_clause, t.is_approved, t.is_eligible, p.name, p.country_code, 
-                                    d.discord_id, d.username, d.discriminator, d.global_name, d.avatar
+                                    p.is_banned, d.discord_id, d.username, d.discriminator, d.global_name, d.avatar
                                     FROM tournament_players t
                                     JOIN players p on t.player_id = p.id
                                     LEFT JOIN users u ON u.player_id = p.id
@@ -367,14 +367,15 @@ class GetTournamentRegistrationsCommand(Command[list[TournamentSquadDetails]]):
                 player_fc_dict: dict[int, list[FriendCode]] = {} # create a dictionary of player fcs so we can give all players their FCs
                 for row in rows:
                     (reg_id, player_id, registration_id, is_squad_captain, is_representative, player_timestamp, is_checked_in, mii_name, can_host, is_invite, selected_fc_id, 
-                     is_bagger_clause, is_approved, is_eligible, player_name, country, 
+                     is_bagger_clause, is_approved, is_eligible, player_name, country, is_banned,
                      discord_id, d_username, d_discriminator, d_global_name, d_avatar) = row
                     if registration_id not in squads:
                         continue
                     player_discord = None
                     if discord_id:
                         player_discord = Discord(discord_id, d_username, d_discriminator, d_global_name, d_avatar)
-                    curr_player = SquadPlayerDetails(reg_id, player_id, registration_id, player_timestamp, is_checked_in, is_approved, is_eligible, mii_name, can_host, player_name, country, player_discord, selected_fc_id, [], is_squad_captain, 
+                    curr_player = SquadPlayerDetails(reg_id, player_id, registration_id, player_timestamp, is_checked_in, is_approved, is_eligible, mii_name, can_host, player_name, country, bool(is_banned), 
+                                                     player_discord, selected_fc_id, [], is_squad_captain, 
                                                      is_representative, is_invite, is_bagger_clause)
                     curr_squad = squads[registration_id]
                     curr_squad.players.append(curr_player)
@@ -495,7 +496,7 @@ class GetPlayerRegistrationCommand(Command[MyTournamentRegistrationDetails]):
             # get all players from squads that the requested player is in
             async with db.execute(f"""SELECT t.id, t.player_id, t.registration_id, t.is_squad_captain, t.is_representative, t.timestamp, t.is_checked_in, 
                                     t.mii_name, t.can_host, t.is_invite, t.selected_fc_id, t.is_bagger_clause, t.is_approved, t.is_eligible, p.name, p.country_code, 
-                                    d.discord_id, d.username, d.discriminator, d.global_name, d.avatar
+                                    p.is_banned, d.discord_id, d.username, d.discriminator, d.global_name, d.avatar
                                     FROM tournament_players t
                                     JOIN players p on t.player_id = p.id
                                     LEFT JOIN users u ON u.player_id = p.id
@@ -509,7 +510,7 @@ class GetPlayerRegistrationCommand(Command[MyTournamentRegistrationDetails]):
                 player_fc_dict: dict[int, list[FriendCode]] = {} # create a dictionary of player fcs so we can give all players their FCs
                 for row in rows:
                     (reg_id, player_id, registration_id, is_squad_captain, is_representative, player_timestamp, is_checked_in, mii_name, can_host, 
-                     is_invite, selected_fc_id, is_bagger_clause, is_approved, is_eligible, player_name, country, 
+                     is_invite, selected_fc_id, is_bagger_clause, is_approved, is_eligible, player_name, country, is_banned,
                      discord_id, d_username, d_discriminator, d_global_name, d_avatar) = row
                     if registration_id not in squads:
                         continue
@@ -517,7 +518,7 @@ class GetPlayerRegistrationCommand(Command[MyTournamentRegistrationDetails]):
                     if discord_id:
                         player_discord = Discord(discord_id, d_username, d_discriminator, d_global_name, d_avatar)
                     curr_player = SquadPlayerDetails(reg_id, player_id, registration_id, player_timestamp, is_checked_in, is_approved, is_eligible,
-                                                     mii_name, can_host, player_name, country, player_discord, selected_fc_id, [], is_squad_captain,
+                                                     mii_name, can_host, player_name, country, bool(is_banned), player_discord, selected_fc_id, [], is_squad_captain,
                                                      is_representative, is_invite, is_bagger_clause)
                     curr_squad = squads[registration_id]
                     curr_squad.players.append(curr_player)

--- a/src/backend/common/data/commands/tournaments/registrations.py
+++ b/src/backend/common/data/commands/tournaments/registrations.py
@@ -354,7 +354,7 @@ class GetTournamentRegistrationsCommand(Command[list[TournamentSquadDetails]]):
                             squad.rosters.append(roster)
             # get tournament players
             async with db.execute("""SELECT t.id, t.player_id, t.registration_id, t.is_squad_captain, t.is_representative, t.timestamp, t.is_checked_in, 
-                                    t.mii_name, t.can_host, t.is_invite, t.selected_fc_id, t.is_bagger_clause, t.is_approved, p.name, p.country_code, 
+                                    t.mii_name, t.can_host, t.is_invite, t.selected_fc_id, t.is_bagger_clause, t.is_approved, t.is_eligible, p.name, p.country_code, 
                                     d.discord_id, d.username, d.discriminator, d.global_name, d.avatar
                                     FROM tournament_players t
                                     JOIN players p on t.player_id = p.id
@@ -367,14 +367,14 @@ class GetTournamentRegistrationsCommand(Command[list[TournamentSquadDetails]]):
                 player_fc_dict: dict[int, list[FriendCode]] = {} # create a dictionary of player fcs so we can give all players their FCs
                 for row in rows:
                     (reg_id, player_id, registration_id, is_squad_captain, is_representative, player_timestamp, is_checked_in, mii_name, can_host, is_invite, selected_fc_id, 
-                     is_bagger_clause, is_approved, player_name, country, 
+                     is_bagger_clause, is_approved, is_eligible, player_name, country, 
                      discord_id, d_username, d_discriminator, d_global_name, d_avatar) = row
                     if registration_id not in squads:
                         continue
                     player_discord = None
                     if discord_id:
                         player_discord = Discord(discord_id, d_username, d_discriminator, d_global_name, d_avatar)
-                    curr_player = SquadPlayerDetails(reg_id, player_id, registration_id, player_timestamp, is_checked_in, is_approved, mii_name, can_host, player_name, country, player_discord, selected_fc_id, [], is_squad_captain, 
+                    curr_player = SquadPlayerDetails(reg_id, player_id, registration_id, player_timestamp, is_checked_in, is_approved, is_eligible, mii_name, can_host, player_name, country, player_discord, selected_fc_id, [], is_squad_captain, 
                                                      is_representative, is_invite, is_bagger_clause)
                     curr_squad = squads[registration_id]
                     curr_squad.players.append(curr_player)
@@ -494,7 +494,7 @@ class GetPlayerRegistrationCommand(Command[MyTournamentRegistrationDetails]):
 
             # get all players from squads that the requested player is in
             async with db.execute(f"""SELECT t.id, t.player_id, t.registration_id, t.is_squad_captain, t.is_representative, t.timestamp, t.is_checked_in, 
-                                    t.mii_name, t.can_host, t.is_invite, t.selected_fc_id, t.is_bagger_clause, t.is_approved, p.name, p.country_code, 
+                                    t.mii_name, t.can_host, t.is_invite, t.selected_fc_id, t.is_bagger_clause, t.is_approved, t.is_eligible, p.name, p.country_code, 
                                     d.discord_id, d.username, d.discriminator, d.global_name, d.avatar
                                     FROM tournament_players t
                                     JOIN players p on t.player_id = p.id
@@ -509,14 +509,14 @@ class GetPlayerRegistrationCommand(Command[MyTournamentRegistrationDetails]):
                 player_fc_dict: dict[int, list[FriendCode]] = {} # create a dictionary of player fcs so we can give all players their FCs
                 for row in rows:
                     (reg_id, player_id, registration_id, is_squad_captain, is_representative, player_timestamp, is_checked_in, mii_name, can_host, 
-                     is_invite, selected_fc_id, is_bagger_clause, is_approved, player_name, country, 
+                     is_invite, selected_fc_id, is_bagger_clause, is_approved, is_eligible, player_name, country, 
                      discord_id, d_username, d_discriminator, d_global_name, d_avatar) = row
                     if registration_id not in squads:
                         continue
                     player_discord = None
                     if discord_id:
                         player_discord = Discord(discord_id, d_username, d_discriminator, d_global_name, d_avatar)
-                    curr_player = SquadPlayerDetails(reg_id, player_id, registration_id, player_timestamp, is_checked_in, is_approved,
+                    curr_player = SquadPlayerDetails(reg_id, player_id, registration_id, player_timestamp, is_checked_in, is_approved, is_eligible,
                                                      mii_name, can_host, player_name, country, player_discord, selected_fc_id, [], is_squad_captain,
                                                      is_representative, is_invite, is_bagger_clause)
                     curr_squad = squads[registration_id]

--- a/src/backend/common/data/commands/tournaments/squads.py
+++ b/src/backend/common/data/commands/tournaments/squads.py
@@ -406,7 +406,7 @@ class GetSquadDetailsCommand(Command[TournamentSquadDetails]):
 
             async with db.execute("""SELECT t.id, t.player_id, t.is_squad_captain, t.is_representative, t.timestamp, t.is_checked_in, 
                                     t.mii_name, t.can_host, t.is_invite, t.selected_fc_id, t.is_bagger_clause, t.is_approved, t.is_eligible,
-                                    p.name, p.country_code, d.discord_id, d.username, d.discriminator, d.global_name, d.avatar
+                                    p.name, p.country_code, p.is_banned, d.discord_id, d.username, d.discriminator, d.global_name, d.avatar
                                     FROM tournament_players t
                                     JOIN players p on t.player_id = p.id
                                     LEFT JOIN users u ON u.player_id = p.id
@@ -420,12 +420,12 @@ class GetSquadDetailsCommand(Command[TournamentSquadDetails]):
                 for row in player_rows:
                     (reg_id, player_id, is_squad_captain, is_representative, player_timestamp, is_checked_in, mii_name, 
                      can_host, is_invite, curr_fc_id, is_bagger_clause, player_is_approved, player_is_eligible, player_name, country, 
-                     discord_id, d_username, d_discriminator, d_global_name, d_avatar) = row
+                     is_banned, discord_id, d_username, d_discriminator, d_global_name, d_avatar) = row
                     player_discord = None
                     if discord_id:
                         player_discord = Discord(discord_id, d_username, d_discriminator, d_global_name, d_avatar)
                     curr_player = SquadPlayerDetails(reg_id, player_id, self.registration_id, player_timestamp, is_checked_in, player_is_approved, player_is_eligible, mii_name, can_host,
-                        player_name, country, player_discord, None, [], is_squad_captain, is_representative, is_invite, is_bagger_clause)
+                        player_name, country, bool(is_banned), player_discord, None, [], is_squad_captain, is_representative, is_invite, is_bagger_clause)
                     players.append(curr_player)
 
                     player_dict[curr_player.player_id] = curr_player

--- a/src/backend/common/data/commands/tournaments/tournaments.py
+++ b/src/backend/common/data/commands/tournaments/tournaments.py
@@ -403,6 +403,7 @@ class GetTournamentSeriesWithTournaments(Command[list[TournamentWithPlacements]]
                     tp.player_id,
                     p.name,
                     p.country_code,
+                    p.is_banned,
                     pla.placement,
                     pla.placement_description,
                     pla.placement_lower_bound,
@@ -452,7 +453,8 @@ class GetTournamentSeriesWithTournaments(Command[list[TournamentWithPlacements]]
                     tp.player_id,
                     tp.registration_id,
                     p.name,
-                    p.country_code
+                    p.country_code,
+                    p.is_banned
                     FROM tournament_players tp
                     LEFT JOIN players p ON tp.player_id = p.id
                     WHERE tp.tournament_id IN (SELECT t.id FROM tournaments t WHERE t.series_id = ? AND t.is_squad = 1 AND t.is_viewable = 1 AND t.is_public = 1)
@@ -480,7 +482,7 @@ class GetTournamentSeriesWithTournaments(Command[list[TournamentWithPlacements]]
             async with db.execute(squad_players_query, (series_id,)) as cursor:
                 rows = await cursor.fetchall()
                 for row in rows:
-                    id, tournament_id, player_id, squad_id, name, country_code = row
+                    id, tournament_id, player_id, squad_id, name, country_code, is_banned = row
                     player = SquadPlayerDetails(
                         id=id,
                         player_id=player_id,
@@ -499,7 +501,8 @@ class GetTournamentSeriesWithTournaments(Command[list[TournamentWithPlacements]]
                         is_representative=False,
                         is_invite=False,
                         is_bagger_clause=False,
-                        is_eligible=True
+                        is_eligible=True,
+                        is_banned=bool(is_banned)
                     )
                     if squad_id not in squad_players_map:
                         squad_players_map[squad_id] = []
@@ -515,6 +518,7 @@ class GetTournamentSeriesWithTournaments(Command[list[TournamentWithPlacements]]
                         player_id,
                         name,
                         country_code,
+                        is_banned,
                         placement,
                         placement_description,
                         placement_lower_bound,
@@ -554,7 +558,8 @@ class GetTournamentSeriesWithTournaments(Command[list[TournamentWithPlacements]]
                                 is_representative=True,
                                 is_invite=True,
                                 is_bagger_clause=False,
-                                is_eligible=True
+                                is_eligible=True,
+                                is_banned=bool(is_banned)
                             )],
                             rosters=[]
                         )

--- a/src/backend/common/data/db/main/tables.py
+++ b/src/backend/common/data/db/main/tables.py
@@ -424,6 +424,7 @@ class TeamMember(TableModel):
     join_date: int
     leave_date: int | None
     is_bagger_clause: bool
+    is_hidden: bool
 
     @staticmethod
     def get_create_table_command():
@@ -433,7 +434,8 @@ class TeamMember(TableModel):
             player_id INTEGER NOT NULL REFERENCES players(id),
             join_date INTEGER NOT NULL,
             leave_date INTEGER,
-            is_bagger_clause BOOLEAN NOT NULL
+            is_bagger_clause BOOLEAN NOT NULL,
+            is_hidden BOOLEAN NOT NULL DEFAULT 0
             )
             """
 

--- a/src/backend/common/data/db/main/tables.py
+++ b/src/backend/common/data/db/main/tables.py
@@ -207,10 +207,12 @@ class Tournament(TableModel):
     show_on_profiles: bool
     require_single_fc: bool
     min_representatives: int | None
+    max_representatives: int | None
     bagger_clause_enabled: bool
     use_series_ruleset: bool
     organizer: str
     location: str | None
+    sync_team_rosters: bool
 
     @staticmethod
     def get_create_table_command():
@@ -251,10 +253,12 @@ class Tournament(TableModel):
             show_on_profiles BOOLEAN NOT NULL,
             require_single_fc BOOLEAN NOT NULL,
             min_representatives INTEGER,
+            max_representatives INTEGER DEFAULT NULL,
             bagger_clause_enabled BOOLEAN NOT NULL,
             use_series_ruleset BOOLEAN DEFAULT 0 NOT NULL,
             organizer TEXT NOT NULL,
-            location TEXT
+            location TEXT,
+            sync_team_rosters BOOLEAN NOT NULL DEFAULT TRUE
             )"""
 
 @dataclass
@@ -310,6 +314,7 @@ class TournamentPlayer(TableModel):
     is_representative: bool
     is_bagger_clause: bool
     is_approved: bool
+    is_eligible: bool
 
     @staticmethod
     def get_create_table_command():
@@ -327,7 +332,8 @@ class TournamentPlayer(TableModel):
             selected_fc_id INTEGER,
             is_representative BOOLEAN NOT NULL,
             is_bagger_clause BOOLEAN NOT NULL,
-            is_approved BOOLEAN DEFAULT FALSE NOT NULL
+            is_approved BOOLEAN DEFAULT FALSE NOT NULL,
+            is_eligible BOOLEAN DEFAULT TRUE NOT NULL
             )"""
     
 @dataclass

--- a/src/backend/common/data/models/moderation.py
+++ b/src/backend/common/data/models/moderation.py
@@ -26,6 +26,8 @@ class IPCheckResponse:
 class AltFlagFilter:
     type: str | None = None
     exclude_fingerprints: bool = False
+    from_date: int | None = None
+    to_date: int | None = None
     page: int | None = None
 
 @dataclass

--- a/src/backend/common/data/models/moderation.py
+++ b/src/backend/common/data/models/moderation.py
@@ -31,6 +31,7 @@ class AltFlagFilter:
 @dataclass
 class PlayerAltFlagRequestData:
     player_id: int
+    exclude_fingerprints: bool = False
 
 @dataclass
 class AltFlagUser:

--- a/src/backend/common/data/models/player_basic.py
+++ b/src/backend/common/data/models/player_basic.py
@@ -7,3 +7,4 @@ class PlayerBasic:
     id: int
     name: str
     country_code: CountryCode
+    is_banned: bool

--- a/src/backend/common/data/models/players.py
+++ b/src/backend/common/data/models/players.py
@@ -38,6 +38,7 @@ class PlayerRoster:
 
 @dataclass
 class PlayerTransferItem:
+    id: int
     team_id: int
     team_name: str
     game: str
@@ -46,6 +47,7 @@ class PlayerTransferItem:
     leave_date: int | None
     is_bagger_clause: bool
     roster_name: str
+    is_hidden: bool
 
 @dataclass
 class PlayerTransferHistory:

--- a/src/backend/common/data/models/tournament_registrations.py
+++ b/src/backend/common/data/models/tournament_registrations.py
@@ -50,6 +50,7 @@ class TournamentPlayerDetails():
     timestamp: int
     is_checked_in: bool
     is_approved: bool
+    is_eligible: bool
     mii_name: str | None
     can_host: bool
     name: str

--- a/src/backend/common/data/models/tournament_registrations.py
+++ b/src/backend/common/data/models/tournament_registrations.py
@@ -55,6 +55,7 @@ class TournamentPlayerDetails():
     can_host: bool
     name: str
     country_code: str | None
+    is_banned: bool
     discord: Discord | None
     selected_fc_id: int | None
     friend_codes: list[FriendCode]

--- a/src/backend/common/data/models/tournaments.py
+++ b/src/backend/common/data/models/tournaments.py
@@ -39,10 +39,12 @@ class TournamentDBFields():
     show_on_profiles: bool
     require_single_fc: bool
     min_representatives: int | None
+    max_representatives: int | None
     bagger_clause_enabled: bool
     use_series_ruleset: bool
     organizer: str
     location: str | None
+    sync_team_rosters: bool
 
 @dataclass
 class TournamentS3Fields():
@@ -88,10 +90,12 @@ class EditTournamentRequestData():
     is_deleted: bool
     show_on_profiles: bool
     min_representatives: int | None
+    max_representatives: int | None
     bagger_clause_enabled: bool
     use_series_ruleset: bool
     organizer: str | None
     location: str | None
+    sync_team_rosters: bool
     # s3-only fields below
     description: str
     ruleset: str

--- a/src/backend/worker/jobs/__init__.py
+++ b/src/backend/worker/jobs/__init__.py
@@ -43,7 +43,8 @@ def get_all_jobs():
         ip_match_detection,
         persistent_cookie_detection,
         fingerprint_match_detection,
-        db_backup
+        db_backup,
+        close_tournament_registrations
     )
     if not _jobs:
         # _jobs.extend(log_processor.get_jobs())
@@ -59,4 +60,5 @@ def get_all_jobs():
         _jobs.extend(persistent_cookie_detection.get_jobs())
         _jobs.extend(fingerprint_match_detection.get_jobs())
         _jobs.extend(db_backup.get_jobs())
+        _jobs.extend(close_tournament_registrations.get_jobs())
     return _jobs

--- a/src/backend/worker/jobs/close_tournament_registrations.py
+++ b/src/backend/worker/jobs/close_tournament_registrations.py
@@ -1,0 +1,23 @@
+from datetime import timedelta
+from worker.data import handle
+from common.data.commands import CloseTournamentRegistrationsCommand
+from worker.jobs import Job
+
+class CloseTournamentRegistrationsJob(Job):
+    @property
+    def name(self):
+        return "Close registrations for tournaments where the registration deadline has passed"
+    
+    @property
+    def delay(self):
+        return timedelta(minutes=1)
+    
+    async def run(self):
+        await handle(CloseTournamentRegistrationsCommand())
+
+_jobs: list[Job] = []
+
+def get_jobs():
+    if not _jobs:
+        _jobs.append(CloseTournamentRegistrationsJob())
+    return _jobs

--- a/src/frontend/src/i18n/de/index.ts
+++ b/src/frontend/src/i18n/de/index.ts
@@ -399,6 +399,8 @@ const de: Translation = {
       IP_USER_COUNT: '{count} users',
       IP_HISTORY: 'IP History',
       NUM_TIMES: '{count} times',
+      EXCLUDE_FINGERPRINTS: 'Exclude fingerprints',
+      INCLUDE_FINGERPRINTS: 'Include fingerprints',
       TABLE: {
         PLAYERS: 'Players',
         TYPE: 'Type',
@@ -590,6 +592,11 @@ const de: Translation = {
       SEND_PASSWORD_RESET_CONFIRM: 'Are you sure you want to send this player a password reset email?',
       SEND_PASSWORD_RESET_SUCCESS: 'Successfully sent the player a password reset email!',
       SEND_PASSWORD_RESET_FAILED: 'Failed to send player a password reset email',
+      HIDE_HIDDEN_TEAM_REGISTRATIONS: 'Hide hidden entries',
+      SHOW_HIDDEN_TEAM_REGISTRATIONS: 'Show hidden entries',
+      TOGGLE_TEAM_REGISTRATION_VISIBILITY_CONFIRM:
+        "Are you sure you would like to toggle this registration's visibility?",
+      TOGGLE_TEAM_REGISTRATION_VISIBILITY_FAILED: 'Failed to toggle visibility',
     },
     SHADOW_PLAYERS: {
       UNCLAIMED_PLAYER_DESCRIPTION:
@@ -756,6 +763,7 @@ const de: Translation = {
       REGISTERED: 'Registriert',
       MAIN_LANGUAGE: 'Hauptsprache',
       MANAGERS: 'Manager',
+      ROSTER: 'Roster',
       ROSTERS: 'Roster',
       PLAYER: 'Spieler',
       PLAYERS: 'Spieler',
@@ -1040,6 +1048,7 @@ const de: Translation = {
       LINK_DISCORD_TO_REGISTER: 'Bitte verknüpfe deinen Discord-Account, um an Turnieren auf MKCentral teilzunehmen.',
       CONFIRM_EMAIL_TO_REGISTER:
         'Bitte bestätigen Sie Ihre E-Mail und füllen Sie die Spielerregistrierung aus, um an Turnieren auf MKCentral teilzunehmen.',
+      INELIGIBLE: 'Ineligible',
     },
     MANAGE: {
       SELECT_TEMPLATE: 'Vorlage auswählen',
@@ -1097,6 +1106,9 @@ const de: Translation = {
       TOURNAMENT_RULESET: 'Turnier-Regelwerk',
       TOURNAMENT_REGISTRATION: 'Turnier-Anmeldung',
       TOURNAMENT_STATUS: 'Status des Turniers',
+      SYNC_TEAM_ROSTERS: 'Remove players who leave their team from squads after registrations have closed?',
+      MAX_REPRESENTATIVES: 'Max # of squad representatives',
+      MIN_LESS_THAN_MAX_REPS: 'Min representatives must be less than or equal to max representatives',
     },
     PLACEMENTS: {
       EDIT_PLACEMENTS: 'Platzierungen bearbeiten',

--- a/src/frontend/src/i18n/en-us/index.ts
+++ b/src/frontend/src/i18n/en-us/index.ts
@@ -588,7 +588,8 @@ const en_us: BaseTranslation = {
       SEND_PASSWORD_RESET_FAILED: 'Failed to send player a password reset email',
       HIDE_HIDDEN_TEAM_REGISTRATIONS: 'Hide hidden entries',
       SHOW_HIDDEN_TEAM_REGISTRATIONS: 'Show hidden entries',
-      TOGGLE_TEAM_REGISTRATION_VISIBILITY_CONFIRM: 'Are you sure you would like to toggle this registration\'s visibility?',
+      TOGGLE_TEAM_REGISTRATION_VISIBILITY_CONFIRM:
+        "Are you sure you would like to toggle this registration's visibility?",
       TOGGLE_TEAM_REGISTRATION_VISIBILITY_FAILED: 'Failed to toggle visibility',
     },
     SHADOW_PLAYERS: {

--- a/src/frontend/src/i18n/en-us/index.ts
+++ b/src/frontend/src/i18n/en-us/index.ts
@@ -393,6 +393,8 @@ const en_us: BaseTranslation = {
       IP_USER_COUNT: '{count:number} users',
       IP_HISTORY: 'IP History',
       NUM_TIMES: '{count:number} times',
+      EXCLUDE_FINGERPRINTS: 'Exclude fingerprints',
+      INCLUDE_FINGERPRINTS: 'Include fingerprints',
       TABLE: {
         PLAYERS: 'Players',
         TYPE: 'Type',

--- a/src/frontend/src/i18n/en-us/index.ts
+++ b/src/frontend/src/i18n/en-us/index.ts
@@ -756,6 +756,7 @@ const en_us: BaseTranslation = {
       REGISTERED: 'Registered',
       MAIN_LANGUAGE: 'Main Language',
       MANAGERS: 'Managers',
+      ROSTER: 'Roster',
       ROSTERS: 'Rosters',
       PLAYER: 'player',
       PLAYERS: 'players',

--- a/src/frontend/src/i18n/en-us/index.ts
+++ b/src/frontend/src/i18n/en-us/index.ts
@@ -1032,6 +1032,7 @@ const en_us: BaseTranslation = {
       LINK_DISCORD_TO_REGISTER: 'Please link your Discord account to participate in tournaments on MKCentral.',
       CONFIRM_EMAIL_TO_REGISTER:
         'Please confirm your email and complete the player registration to participate in tournaments on MKCentral.',
+      INELIGIBLE: 'Ineligible',
     },
     MANAGE: {
       SELECT_TEMPLATE: 'Select Template',
@@ -1089,6 +1090,9 @@ const en_us: BaseTranslation = {
       TOURNAMENT_RULESET: 'Tournament Ruleset',
       TOURNAMENT_REGISTRATION: 'Tournament Registration',
       TOURNAMENT_STATUS: 'Tournament Status',
+      SYNC_TEAM_ROSTERS: 'Remove players who leave their team from squads after registrations have closed?',
+      MAX_REPRESENTATIVES: 'Max # of squad representatives',
+      MIN_LESS_THAN_MAX_REPS: 'Min representatives must be less than or equal to max representatives',
     },
     PLACEMENTS: {
       EDIT_PLACEMENTS: 'Edit Placements',

--- a/src/frontend/src/i18n/en-us/index.ts
+++ b/src/frontend/src/i18n/en-us/index.ts
@@ -584,6 +584,10 @@ const en_us: BaseTranslation = {
       SEND_PASSWORD_RESET_CONFIRM: 'Are you sure you want to send this player a password reset email?',
       SEND_PASSWORD_RESET_SUCCESS: 'Successfully sent the player a password reset email!',
       SEND_PASSWORD_RESET_FAILED: 'Failed to send player a password reset email',
+      HIDE_HIDDEN_TEAM_REGISTRATIONS: 'Hide hidden entries',
+      SHOW_HIDDEN_TEAM_REGISTRATIONS: 'Show hidden entries',
+      TOGGLE_TEAM_REGISTRATION_VISIBILITY_CONFIRM: 'Are you sure you would like to toggle this registration\'s visibility?',
+      TOGGLE_TEAM_REGISTRATION_VISIBILITY_FAILED: 'Failed to toggle visibility',
     },
     SHADOW_PLAYERS: {
       UNCLAIMED_PLAYER_DESCRIPTION:

--- a/src/frontend/src/i18n/es/index.ts
+++ b/src/frontend/src/i18n/es/index.ts
@@ -398,6 +398,8 @@ const es: Translation = {
       IP_USER_COUNT: '{count} users',
       IP_HISTORY: 'IP History',
       NUM_TIMES: '{count} times',
+      EXCLUDE_FINGERPRINTS: 'Exclude fingerprints',
+      INCLUDE_FINGERPRINTS: 'Include fingerprints',
       TABLE: {
         PLAYERS: 'Jugadores',
         TYPE: 'Tipo',
@@ -589,6 +591,11 @@ const es: Translation = {
       SEND_PASSWORD_RESET_CONFIRM: 'Are you sure you want to send this player a password reset email?',
       SEND_PASSWORD_RESET_SUCCESS: 'Successfully sent the player a password reset email!',
       SEND_PASSWORD_RESET_FAILED: 'Failed to send player a password reset email',
+      HIDE_HIDDEN_TEAM_REGISTRATIONS: 'Hide hidden entries',
+      SHOW_HIDDEN_TEAM_REGISTRATIONS: 'Show hidden entries',
+      TOGGLE_TEAM_REGISTRATION_VISIBILITY_CONFIRM:
+        "Are you sure you would like to toggle this registration's visibility?",
+      TOGGLE_TEAM_REGISTRATION_VISIBILITY_FAILED: 'Failed to toggle visibility',
     },
     SHADOW_PLAYERS: {
       UNCLAIMED_PLAYER_DESCRIPTION:
@@ -754,6 +761,7 @@ const es: Translation = {
       REGISTERED: 'Registrado',
       MAIN_LANGUAGE: 'Idioma principal',
       MANAGERS: 'Managers',
+      ROSTER: 'Roster',
       ROSTERS: 'Rosters',
       PLAYER: 'jugador',
       PLAYERS: 'jugadores',
@@ -1036,6 +1044,7 @@ const es: Translation = {
       LINK_DISCORD_TO_REGISTER: 'Por favor, sincroniza tu cuenta de Discord para participar en torneos de MKCentral.',
       CONFIRM_EMAIL_TO_REGISTER:
         'Por favor, confirma tu email y completa el registro de jugador para participar en torneos de MKCentral.',
+      INELIGIBLE: 'Ineligible',
     },
     MANAGE: {
       SELECT_TEMPLATE: 'Seleccionar plantilla',
@@ -1094,6 +1103,9 @@ const es: Translation = {
       TOURNAMENT_RULESET: 'Normas del torneo',
       TOURNAMENT_REGISTRATION: 'Inscripción al torneo',
       TOURNAMENT_STATUS: 'Estado del torneo',
+      SYNC_TEAM_ROSTERS: 'Remove players who leave their team from squads after registrations have closed?',
+      MAX_REPRESENTATIVES: 'Max # of squad representatives',
+      MIN_LESS_THAN_MAX_REPS: 'Min representatives must be less than or equal to max representatives',
     },
     PLACEMENTS: {
       EDIT_PLACEMENTS: 'Editar posiciones',

--- a/src/frontend/src/i18n/fr/index.ts
+++ b/src/frontend/src/i18n/fr/index.ts
@@ -398,6 +398,8 @@ const fr: Translation = {
       IP_USER_COUNT: '{count} utilisateurs',
       IP_HISTORY: "Historique de l'IP",
       NUM_TIMES: '{count} fois',
+      EXCLUDE_FINGERPRINTS: 'Exclude fingerprints',
+      INCLUDE_FINGERPRINTS: 'Include fingerprints',
       TABLE: {
         PLAYERS: 'Joueurs',
         TYPE: 'Type',
@@ -589,6 +591,11 @@ const fr: Translation = {
       SEND_PASSWORD_RESET_CONFIRM: 'Are you sure you want to send this player a password reset email?',
       SEND_PASSWORD_RESET_SUCCESS: 'Successfully sent the player a password reset email!',
       SEND_PASSWORD_RESET_FAILED: 'Failed to send player a password reset email',
+      HIDE_HIDDEN_TEAM_REGISTRATIONS: 'Hide hidden entries',
+      SHOW_HIDDEN_TEAM_REGISTRATIONS: 'Show hidden entries',
+      TOGGLE_TEAM_REGISTRATION_VISIBILITY_CONFIRM:
+        "Are you sure you would like to toggle this registration's visibility?",
+      TOGGLE_TEAM_REGISTRATION_VISIBILITY_FAILED: 'Failed to toggle visibility',
     },
     SHADOW_PLAYERS: {
       UNCLAIMED_PLAYER_DESCRIPTION:
@@ -755,6 +762,7 @@ const fr: Translation = {
       REGISTERED: 'Date de création',
       MAIN_LANGUAGE: 'Langue Principale',
       MANAGERS: 'Managers',
+      ROSTER: 'Roster',
       ROSTERS: 'Effectifs',
       PLAYER: 'joueur',
       PLAYERS: 'joueurs',
@@ -1040,6 +1048,7 @@ const fr: Translation = {
       LINK_DISCORD_TO_REGISTER: 'Veuillez lier votre compte Discord pour participer aux tournois sur MKCentral.',
       CONFIRM_EMAIL_TO_REGISTER:
         'Veuillez confirmer votre e-mail et compléter votre inscription de joueur pour participer aux tournois sur MKCentral.',
+      INELIGIBLE: 'Ineligible',
     },
     MANAGE: {
       SELECT_TEMPLATE: 'Sélection un template',
@@ -1098,6 +1107,9 @@ const fr: Translation = {
       TOURNAMENT_RULESET: 'Règlement du tournoi',
       TOURNAMENT_REGISTRATION: 'Inscription au tournoi',
       TOURNAMENT_STATUS: 'Statut du tournoi',
+      SYNC_TEAM_ROSTERS: 'Remove players who leave their team from squads after registrations have closed?',
+      MAX_REPRESENTATIVES: 'Max # of squad representatives',
+      MIN_LESS_THAN_MAX_REPS: 'Min representatives must be less than or equal to max representatives',
     },
     PLACEMENTS: {
       EDIT_PLACEMENTS: 'Modifier les placements',

--- a/src/frontend/src/i18n/i18n-types.ts
+++ b/src/frontend/src/i18n/i18n-types.ts
@@ -1450,6 +1450,14 @@ type RootTranslation = {
 			 * @param {number} count
 			 */
 			NUM_TIMES: RequiredParams<'count'>
+			/**
+			 * E​x​c​l​u​d​e​ ​f​i​n​g​e​r​p​r​i​n​t​s
+			 */
+			EXCLUDE_FINGERPRINTS: string
+			/**
+			 * I​n​c​l​u​d​e​ ​f​i​n​g​e​r​p​r​i​n​t​s
+			 */
+			INCLUDE_FINGERPRINTS: string
 			TABLE: {
 				/**
 				 * P​l​a​y​e​r​s
@@ -6839,6 +6847,14 @@ export type TranslationFunctions = {
 			 * {count} times
 			 */
 			NUM_TIMES: (arg: { count: number }) => LocalizedString
+			/**
+			 * Exclude fingerprints
+			 */
+			EXCLUDE_FINGERPRINTS: () => LocalizedString
+			/**
+			 * Include fingerprints
+			 */
+			INCLUDE_FINGERPRINTS: () => LocalizedString
 			TABLE: {
 				/**
 				 * Players

--- a/src/frontend/src/i18n/i18n-types.ts
+++ b/src/frontend/src/i18n/i18n-types.ts
@@ -2862,6 +2862,10 @@ type RootTranslation = {
 			 */
 			MANAGERS: string
 			/**
+			 * R​o​s​t​e​r
+			 */
+			ROSTER: string
+			/**
 			 * R​o​s​t​e​r​s
 			 */
 			ROSTERS: string
@@ -8175,6 +8179,10 @@ export type TranslationFunctions = {
 			 * Managers
 			 */
 			MANAGERS: () => LocalizedString
+			/**
+			 * Roster
+			 */
+			ROSTER: () => LocalizedString
 			/**
 			 * Rosters
 			 */

--- a/src/frontend/src/i18n/i18n-types.ts
+++ b/src/frontend/src/i18n/i18n-types.ts
@@ -2222,6 +2222,22 @@ type RootTranslation = {
 			 * F​a​i​l​e​d​ ​t​o​ ​s​e​n​d​ ​p​l​a​y​e​r​ ​a​ ​p​a​s​s​w​o​r​d​ ​r​e​s​e​t​ ​e​m​a​i​l
 			 */
 			SEND_PASSWORD_RESET_FAILED: string
+			/**
+			 * H​i​d​e​ ​h​i​d​d​e​n​ ​e​n​t​r​i​e​s
+			 */
+			HIDE_HIDDEN_TEAM_REGISTRATIONS: string
+			/**
+			 * S​h​o​w​ ​h​i​d​d​e​n​ ​e​n​t​r​i​e​s
+			 */
+			SHOW_HIDDEN_TEAM_REGISTRATIONS: string
+			/**
+			 * A​r​e​ ​y​o​u​ ​s​u​r​e​ ​y​o​u​ ​w​o​u​l​d​ ​l​i​k​e​ ​t​o​ ​t​o​g​g​l​e​ ​t​h​i​s​ ​r​e​g​i​s​t​r​a​t​i​o​n​'​s​ ​v​i​s​i​b​i​l​i​t​y​?
+			 */
+			TOGGLE_TEAM_REGISTRATION_VISIBILITY_CONFIRM: string
+			/**
+			 * F​a​i​l​e​d​ ​t​o​ ​t​o​g​g​l​e​ ​v​i​s​i​b​i​l​i​t​y
+			 */
+			TOGGLE_TEAM_REGISTRATION_VISIBILITY_FAILED: string
 		}
 		SHADOW_PLAYERS: {
 			/**
@@ -7527,6 +7543,22 @@ export type TranslationFunctions = {
 			 * Failed to send player a password reset email
 			 */
 			SEND_PASSWORD_RESET_FAILED: () => LocalizedString
+			/**
+			 * Hide hidden entries
+			 */
+			HIDE_HIDDEN_TEAM_REGISTRATIONS: () => LocalizedString
+			/**
+			 * Show hidden entries
+			 */
+			SHOW_HIDDEN_TEAM_REGISTRATIONS: () => LocalizedString
+			/**
+			 * Are you sure you would like to toggle this registration's visibility?
+			 */
+			TOGGLE_TEAM_REGISTRATION_VISIBILITY_CONFIRM: () => LocalizedString
+			/**
+			 * Failed to toggle visibility
+			 */
+			TOGGLE_TEAM_REGISTRATION_VISIBILITY_FAILED: () => LocalizedString
 		}
 		SHADOW_PLAYERS: {
 			/**

--- a/src/frontend/src/i18n/i18n-types.ts
+++ b/src/frontend/src/i18n/i18n-types.ts
@@ -3914,6 +3914,10 @@ type RootTranslation = {
 			 * P​l​e​a​s​e​ ​c​o​n​f​i​r​m​ ​y​o​u​r​ ​e​m​a​i​l​ ​a​n​d​ ​c​o​m​p​l​e​t​e​ ​t​h​e​ ​p​l​a​y​e​r​ ​r​e​g​i​s​t​r​a​t​i​o​n​ ​t​o​ ​p​a​r​t​i​c​i​p​a​t​e​ ​i​n​ ​t​o​u​r​n​a​m​e​n​t​s​ ​o​n​ ​M​K​C​e​n​t​r​a​l​.
 			 */
 			CONFIRM_EMAIL_TO_REGISTER: string
+			/**
+			 * I​n​e​l​i​g​i​b​l​e
+			 */
+			INELIGIBLE: string
 		}
 		MANAGE: {
 			/**
@@ -4136,6 +4140,18 @@ type RootTranslation = {
 			 * T​o​u​r​n​a​m​e​n​t​ ​S​t​a​t​u​s
 			 */
 			TOURNAMENT_STATUS: string
+			/**
+			 * R​e​m​o​v​e​ ​p​l​a​y​e​r​s​ ​w​h​o​ ​l​e​a​v​e​ ​t​h​e​i​r​ ​t​e​a​m​ ​f​r​o​m​ ​s​q​u​a​d​s​ ​a​f​t​e​r​ ​r​e​g​i​s​t​r​a​t​i​o​n​s​ ​h​a​v​e​ ​c​l​o​s​e​d​?
+			 */
+			SYNC_TEAM_ROSTERS: string
+			/**
+			 * M​a​x​ ​#​ ​o​f​ ​s​q​u​a​d​ ​r​e​p​r​e​s​e​n​t​a​t​i​v​e​s
+			 */
+			MAX_REPRESENTATIVES: string
+			/**
+			 * M​i​n​ ​r​e​p​r​e​s​e​n​t​a​t​i​v​e​s​ ​m​u​s​t​ ​b​e​ ​l​e​s​s​ ​t​h​a​n​ ​o​r​ ​e​q​u​a​l​ ​t​o​ ​m​a​x​ ​r​e​p​r​e​s​e​n​t​a​t​i​v​e​s
+			 */
+			MIN_LESS_THAN_MAX_REPS: string
 		}
 		PLACEMENTS: {
 			/**
@@ -9163,6 +9179,10 @@ export type TranslationFunctions = {
 			 * Please confirm your email and complete the player registration to participate in tournaments on MKCentral.
 			 */
 			CONFIRM_EMAIL_TO_REGISTER: () => LocalizedString
+			/**
+			 * Ineligible
+			 */
+			INELIGIBLE: () => LocalizedString
 		}
 		MANAGE: {
 			/**
@@ -9385,6 +9405,18 @@ export type TranslationFunctions = {
 			 * Tournament Status
 			 */
 			TOURNAMENT_STATUS: () => LocalizedString
+			/**
+			 * Remove players who leave their team from squads after registrations have closed?
+			 */
+			SYNC_TEAM_ROSTERS: () => LocalizedString
+			/**
+			 * Max # of squad representatives
+			 */
+			MAX_REPRESENTATIVES: () => LocalizedString
+			/**
+			 * Min representatives must be less than or equal to max representatives
+			 */
+			MIN_LESS_THAN_MAX_REPS: () => LocalizedString
 		}
 		PLACEMENTS: {
 			/**

--- a/src/frontend/src/i18n/ja/index.ts
+++ b/src/frontend/src/i18n/ja/index.ts
@@ -395,6 +395,8 @@ const ja: Translation = {
       IP_USER_COUNT: '{count} users',
       IP_HISTORY: 'IP History',
       NUM_TIMES: '{count} times',
+      EXCLUDE_FINGERPRINTS: 'Exclude fingerprints',
+      INCLUDE_FINGERPRINTS: 'Include fingerprints',
       TABLE: {
         PLAYERS: 'Players',
         TYPE: 'Type',
@@ -586,6 +588,11 @@ const ja: Translation = {
       SEND_PASSWORD_RESET_CONFIRM: 'Are you sure you want to send this player a password reset email?',
       SEND_PASSWORD_RESET_SUCCESS: 'Successfully sent the player a password reset email!',
       SEND_PASSWORD_RESET_FAILED: 'Failed to send player a password reset email',
+      HIDE_HIDDEN_TEAM_REGISTRATIONS: 'Hide hidden entries',
+      SHOW_HIDDEN_TEAM_REGISTRATIONS: 'Show hidden entries',
+      TOGGLE_TEAM_REGISTRATION_VISIBILITY_CONFIRM:
+        "Are you sure you would like to toggle this registration's visibility?",
+      TOGGLE_TEAM_REGISTRATION_VISIBILITY_FAILED: 'Failed to toggle visibility',
     },
     SHADOW_PLAYERS: {
       UNCLAIMED_PLAYER_DESCRIPTION:
@@ -749,6 +756,7 @@ const ja: Translation = {
       REGISTERED: '登録済み',
       MAIN_LANGUAGE: '主な使用言語',
       MANAGERS: 'マネージャー',
+      ROSTER: 'Roster',
       ROSTERS: 'Rosters',
       PLAYER: 'プレイヤー',
       PLAYERS: 'プレイヤー',
@@ -1030,6 +1038,7 @@ const ja: Translation = {
       SIGN_IN_REGISTER_TO_REGISTER: 'MKCentralで大会に参加するには、サインインするか登録する必要があります',
       LINK_DISCORD_TO_REGISTER: 'MKCentralの大会に参加するには、Discordアカウントと連携して下さい。',
       CONFIRM_EMAIL_TO_REGISTER: 'MKCentralの大会に参加するには、Eメールを確認し、プレイヤー登録を完了してください。',
+      INELIGIBLE: 'Ineligible',
     },
     MANAGE: {
       SELECT_TEMPLATE: 'テンプレート選択',
@@ -1087,6 +1096,9 @@ const ja: Translation = {
       TOURNAMENT_RULESET: '大会ルールセット',
       TOURNAMENT_REGISTRATION: '大会申し込み',
       TOURNAMENT_STATUS: '大会状況',
+      SYNC_TEAM_ROSTERS: 'Remove players who leave their team from squads after registrations have closed?',
+      MAX_REPRESENTATIVES: 'Max # of squad representatives',
+      MIN_LESS_THAN_MAX_REPS: 'Min representatives must be less than or equal to max representatives',
     },
     PLACEMENTS: {
       EDIT_PLACEMENTS: '大会結果登録',

--- a/src/frontend/src/lib/components/badges/IneligibleBadge.svelte
+++ b/src/frontend/src/lib/components/badges/IneligibleBadge.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+    import Badge from "./Badge.svelte";
+    import LL from "$i18n/i18n-svelte";
+</script>
+
+<Badge badgeClass="ineligible_badge">{$LL.TOURNAMENTS.REGISTRATIONS.INELIGIBLE()}</Badge>

--- a/src/frontend/src/lib/components/badges/badge_styles.css
+++ b/src/frontend/src/lib/components/badges/badge_styles.css
@@ -37,6 +37,10 @@ span.badge {
   background-color: #00bd6e;
   border: 1px solid #047942;
 }
+.ineligible_badge {
+  background-color: #a8a8a8;
+  border: 1px solid #929292;
+}
 
 .game_mkt_badge {
   background-color: #a1385d;

--- a/src/frontend/src/lib/components/common/ColorSelect.svelte
+++ b/src/frontend/src/lib/components/common/ColorSelect.svelte
@@ -16,7 +16,7 @@
 <div class="color-select">
     <select {name} bind:value={color}>
         {#each sorted_colors as c}
-            <option value={c.id}>{color_strings[c.label]()}</option>
+            <option value={c.id} style="background-color:{c.value}">{color_strings[c.label]()}</option>
         {/each}
     </select>
     <TagBadge {tag} {color}/>

--- a/src/frontend/src/lib/components/common/PlayerName.svelte
+++ b/src/frontend/src/lib/components/common/PlayerName.svelte
@@ -9,7 +9,9 @@
 <a href="/{$page.params.lang}/registry/players/profile?id={player.id}">
     <div class="player">
         <Flag country_code={player.country_code}/>
-        {player.name}
+        <span class={player.is_banned ? "banned_name" : ""}>
+            {player.name}
+        </span>
     </div>
 </a>
 
@@ -18,5 +20,9 @@
         display: flex;
         gap: 5px;
         align-items: center;
+    }
+    .banned_name {
+        opacity: 0.7;
+        text-decoration: line-through;
     }
 </style>

--- a/src/frontend/src/lib/components/common/PlayerSearch.svelte
+++ b/src/frontend/src/lib/components/common/PlayerSearch.svelte
@@ -91,7 +91,7 @@
             <col class="select"/>
             <tbody>
               {#each results as result}
-                <tr on:click={() => set_option(result)}>
+                <tr on:click={() => set_option(result)} title="Player ID: {result.id}">
                   <td on:click={() => set_option(result)}>
                     <Flag country_code={result.country_code}/>
                   </td>

--- a/src/frontend/src/lib/components/moderator/PlayerAltFlags.svelte
+++ b/src/frontend/src/lib/components/moderator/PlayerAltFlags.svelte
@@ -9,21 +9,38 @@
 
     let alt_dialog: Dialog;
     let flags: AltFlag[] = [];
+    let exclude_fingerprints = true;
 
     export function open() {
         alt_dialog.open();
     }
 
-    onMount(async() => {
-        const res = await fetch(`/api/moderator/playerAltFlags?player_id=${player_id}`);
+    async function fetchFlags() {
+        const res = await fetch(`/api/moderator/playerAltFlags?player_id=${player_id}&exclude_fingerprints=${exclude_fingerprints}`);
         if(res.status === 200) {
             const body: AltFlag[] = await res.json();
             console.log(body);
             flags = body;
         }
+    }
+
+    onMount(async() => {
+        fetchFlags();
     });
 </script>
 
 <Dialog bind:this={alt_dialog} header={$LL.MODERATOR.ALT_DETECTION.PLAYER_ALT_FLAGS()}>
-    <AltFlags {flags}/>
+    <div>
+        <select bind:value={exclude_fingerprints} on:change={fetchFlags}>
+            <option value={true}>
+                {$LL.MODERATOR.ALT_DETECTION.EXCLUDE_FINGERPRINTS()}
+            </option>
+            <option value={false}>
+                {$LL.MODERATOR.ALT_DETECTION.INCLUDE_FINGERPRINTS()}
+            </option>
+        </select>
+    </div>
+    {#key flags}
+        <AltFlags {flags}/>
+    {/key}
 </Dialog>

--- a/src/frontend/src/lib/components/registry/players/PlayerRegistrationHistory.svelte
+++ b/src/frontend/src/lib/components/registry/players/PlayerRegistrationHistory.svelte
@@ -9,9 +9,12 @@
   import LL from '$i18n/i18n-svelte';
   import { onMount } from 'svelte';
   import BaggerBadge from '$lib/components/badges/BaggerBadge.svelte';
+  import { user } from '$lib/stores/stores';
+  import { check_permission, permissions } from '$lib/util/permissions';
 
   let game: string | null = null;
   let mode: string | null = null;
+  let show_hidden = false;
   let history: PlayerTransferItem[] = [];
   let filtered_history: PlayerTransferItem[] = [];
 
@@ -42,6 +45,25 @@
     if (mode) {
       filtered_history = filtered_history.filter((item) => item.mode === mode);
     }
+    if(!show_hidden || !check_permission($user, permissions.edit_player)) {
+      filtered_history = filtered_history.filter((item) => !item.is_hidden);
+    }
+  }
+
+  async function toggleTransferItemVisibility(record: PlayerTransferItem) {
+    let conf = window.confirm($LL.PLAYERS.PROFILE.TOGGLE_TEAM_REGISTRATION_VISIBILITY_CONFIRM());
+    if(!conf) return;
+    const endpoint = `/api/registry/players/${player.id}/toggleTransferItemVisibility/${record.id}`;
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const result = await response.json();
+    if (response.status < 300) {
+      window.location.reload();
+    } else {
+      alert(`${$LL.PLAYERS.PROFILE.TOGGLE_TEAM_REGISTRATION_VISIBILITY_FAILED()}: ${result['title']}`);
+    }
   }
 
   onMount(fetchData);
@@ -56,8 +78,16 @@
         <form on:submit|preventDefault={filterData}>
           <div class="flex flex-row flex-wrap items-center justify-center">
             <GameModeSelect bind:game bind:mode hide_labels is_team all_option inline/>
+            {#if check_permission($user, permissions.edit_player)}
+              <div class="ml-1 my-2">
+                <select bind:value={show_hidden}>
+                  <option value={false}>{$LL.PLAYERS.PROFILE.HIDE_HIDDEN_TEAM_REGISTRATIONS()}</option>
+                  <option value={true}>{$LL.PLAYERS.PROFILE.SHOW_HIDDEN_TEAM_REGISTRATIONS()}</option>
+                </select>
+              </div>
+            {/if}
             <div class="ml-1 my-2">
-              <Button type="submit">Filter</Button>
+              <Button type="submit">{$LL.COMMON.FILTER()}</Button>
             </div>
           </div>
         </form>
@@ -66,11 +96,12 @@
             <tr>
               <th>Team</th>
               <th>Registration Period</th>
+              <th/>
             </tr>
           </thead>
           <tbody>
             {#each filtered_history as record, i}
-              <tr class="row-{i % 2}">
+              <tr class="row-{i % 2} {record.is_hidden ? "hidden-item" : ""}">
                 <td>
                   <a
                     href="/{$page.params.lang}/registry/teams/profile?id={record.team_id}"
@@ -85,6 +116,17 @@
                 <td>
                   {toDate(record.join_date)} - {record.leave_date ? toDate(record.leave_date) : 'Present'}
                 </td>
+                <td>
+                  {#if check_permission($user, permissions.edit_player)}
+                    <button class="link-button" on:click={() => toggleTransferItemVisibility(record)}>
+                      {#if !record.is_hidden}
+                        {$LL.COMMON.HIDE()}
+                      {:else}
+                        {$LL.COMMON.SHOW()}
+                      {/if}
+                    </button>
+                  {/if}
+                </td>
               </tr>
             {/each}
           </tbody>
@@ -93,3 +135,15 @@
     </div>
   </Section>
 {/if}
+
+<style>
+  .hidden-item {
+    opacity: 0.7;
+  }
+  button.link-button {
+    background-color: transparent;
+    border: none;
+    color: white;
+    cursor: pointer;
+  }
+</style>

--- a/src/frontend/src/lib/components/registry/players/PlayerTournamentHistory.svelte
+++ b/src/frontend/src/lib/components/registry/players/PlayerTournamentHistory.svelte
@@ -8,7 +8,7 @@
   import Button from '$lib/components/common/buttons/Button.svelte';
   import LL from '$i18n/i18n-svelte';
   import GameModeSelect from '$lib/components/common/GameModeSelect.svelte';
-  import PlayerName from '$lib/components/tournaments/registration/PlayerName.svelte';
+  import TournamentPlayerName from '$lib/components/tournaments/registration/TournamentPlayerName.svelte';
   export let player: PlayerInfo;
 
   let mode: string | null = null;
@@ -167,9 +167,9 @@
                         {#each placement.partners as partner, i}
                           <div>
                             {#if i + 1 < placement.partners.length}
-                              <PlayerName player_id={partner.player_id} name="{partner.player_name}," />
+                              <TournamentPlayerName player_id={partner.player_id} name="{partner.player_name}," />
                             {:else}
-                              <PlayerName player_id={partner.player_id} name={partner.player_name}/>
+                              <TournamentPlayerName player_id={partner.player_id} name={partner.player_name}/>
                             {/if}
                           </div>
                         {/each}

--- a/src/frontend/src/lib/components/registry/teams/ForceTransferPlayer.svelte
+++ b/src/frontend/src/lib/components/registry/teams/ForceTransferPlayer.svelte
@@ -69,6 +69,9 @@
             alert(`${$LL.MODERATOR.FORCE_TRANSFER_FAILED()}: ${result['title']}`);
         }
     }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mode_strings: any = $LL.MODES;
 </script>
 
 <PlayerSearch bind:player={player} on:change={getPlayerRosters}/>
@@ -84,7 +87,7 @@
                     {#each player.rosters as roster}
                         <option value={roster}>
                             {roster.roster_name}
-                            ({roster.game.toUpperCase()})
+                            ({roster.game.toUpperCase()} {mode_strings[roster.mode.toUpperCase()]()})
                             {#if roster.is_bagger_clause}
                                 ({$LL.COMMON.BAGGER()})
                             {/if}

--- a/src/frontend/src/lib/components/registry/teams/TeamTournamentHistory.svelte
+++ b/src/frontend/src/lib/components/registry/teams/TeamTournamentHistory.svelte
@@ -54,6 +54,11 @@
     if (mode) {
       filtered_team_placements = filtered_team_placements.filter((item) => item.mode === mode);
     }
+    if (from) {
+      filtered_team_placements = filtered_team_placements.filter((item) => {
+        return item.date_end >= Date.parse(String(from)) / 1000;
+      });
+    }
     if (to) {
       filtered_team_placements = filtered_team_placements.filter((item) => {
         return item.date_end <= Date.parse(String(to)) / 1000;

--- a/src/frontend/src/lib/components/registry/teams/TeamTournamentHistory.svelte
+++ b/src/frontend/src/lib/components/registry/teams/TeamTournamentHistory.svelte
@@ -8,6 +8,7 @@
   import Button from '$lib/components/common/buttons/Button.svelte';
   import LL from '$i18n/i18n-svelte';
   import GameModeSelect from '$lib/components/common/GameModeSelect.svelte';
+  import { game_abbreviations } from '$lib/util/util';
 
   export let team: Team;
 
@@ -15,9 +16,13 @@
   let game: string | null = null;
   let from: string | null = null;
   let to: string | null = null;
+  let roster_id: number | null = null;
   let team_placements: TeamTournamentPlacement[] = [];
   let filtered_team_placements: TeamTournamentPlacement[] = [];
   let podium_style: { [key: number]: string } = { 1: 'gold', 2: 'silver', 3: 'bronze' };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mode_strings: any = $LL.MODES;
 
   function toDate(unix_timestamp: number) {
     return new Date(unix_timestamp * 1000).toLocaleDateString();
@@ -54,6 +59,9 @@
         return item.date_end <= Date.parse(String(to)) / 1000;
       });
     }
+    if(roster_id) {
+      filtered_team_placements = filtered_team_placements.filter((item) => item.rosters.some((r) => r.roster_id === roster_id));
+    }
 
     filtered_team_placements = filtered_team_placements.sort((a, b) => {
       return b.date_start - a.date_start;
@@ -78,6 +86,17 @@
             <div class="flex flex-row items-center">
               <div class="w-12 mx-2">{$LL.COMMON.TO()}</div>
               <input class="w-48" name="to" type="date" bind:value={to} />
+            </div>
+            <div class="flex flex-row items-center">
+              <div class="w-12 mx-2">{$LL.TEAMS.PROFILE.ROSTER()}</div>
+              <select bind:value={roster_id}>
+                <option value={null}>{$LL.TEAMS.PROFILE.ALL_ROSTERS()}</option>
+                {#each team.rosters as roster}
+                  <option value={roster.id}>
+                    {roster.name} ({game_abbreviations[roster.game]} {mode_strings[roster.mode.toUpperCase()]()})
+                  </option>
+                {/each}
+              </select>
             </div>
           </div>
           <div class="ml-1 my-2">

--- a/src/frontend/src/lib/components/registry/teams/TransferList.svelte
+++ b/src/frontend/src/lib/components/registry/teams/TransferList.svelte
@@ -174,7 +174,7 @@
                 </div>
                 <div class="right field">
                     {#if transfer.roster_leave}
-                        <a href="/{$page.params.lang}/registry/teams/profile?id={transfer.roster_leave.team_id}">
+                        <a href="/{$page.params.lang}/registry/teams/profile?id={transfer.roster_leave.team_id}" title={transfer.roster_leave.roster_name}>
                             <TagBadge tag={transfer.roster_leave.roster_tag} color={transfer.roster_leave.team_color}/>
                         </a>
                     {:else}
@@ -182,7 +182,7 @@
                     {/if}
                     <ArrowRight/>
                     {#if transfer.roster_join}
-                        <a href="/{$page.params.lang}/registry/teams/profile?id={transfer.roster_join.team_id}">
+                        <a href="/{$page.params.lang}/registry/teams/profile?id={transfer.roster_join.team_id}" title={transfer.roster_join.roster_name}>
                             <TagBadge tag={transfer.roster_join.roster_tag} color={transfer.roster_join.team_color}/>
                         </a>
                     {:else}

--- a/src/frontend/src/lib/components/tournaments/CreateEditTournamentForm.svelte
+++ b/src/frontend/src/lib/components/tournaments/CreateEditTournamentForm.svelte
@@ -34,6 +34,7 @@
     teams_only: false,
     team_members_only: false,
     min_representatives: null,
+    max_representatives: null,
     host_status_required: false,
     mii_name_required: false,
     require_single_fc: false,
@@ -57,6 +58,7 @@
     bagger_clause_enabled: false,
     logo_file: null,
     remove_logo: false,
+    sync_team_rosters: false,
   };
 
   let is_edit = tournament_id ? true : false; // if we specified a tournament id, assume we're editing that tournament
@@ -104,6 +106,12 @@
     data.date_end = Number(date_end);
     data.registration_deadline = registration_deadline;
 
+    if(data.min_representatives && data.max_representatives && data.min_representatives > data.max_representatives) {
+      alert($LL.TOURNAMENTS.MANAGE.MIN_LESS_THAN_MAX_REPS());
+      working = false;
+      return;
+    }
+
     let payload = data;
     console.log(payload);
     const endpoint = '/api/tournaments/create';
@@ -149,6 +157,12 @@
     data.date_start = Number(date_start);
     data.date_end = Number(date_end);
     data.registration_deadline = registration_deadline;
+
+    if(data.min_representatives && data.max_representatives && data.min_representatives > data.max_representatives) {
+      alert($LL.TOURNAMENTS.MANAGE.MIN_LESS_THAN_MAX_REPS());
+      working = false;
+      return;
+    }
 
     let payload = data;
     console.log(payload);

--- a/src/frontend/src/lib/components/tournaments/TournamentDetailsForm.svelte
+++ b/src/frontend/src/lib/components/tournaments/TournamentDetailsForm.svelte
@@ -54,6 +54,7 @@
       data.teams_only = false;
       data.team_members_only = false;
       data.min_representatives = null;
+      data.max_representatives = null;
     }
     if (!data.checkins_enabled) {
       data.checkins_open = false;
@@ -74,6 +75,9 @@
     }
     if(!data.is_viewable) {
       data.is_public = false;
+    }
+    if(!data.team_members_only) {
+      data.sync_team_rosters = false;
     }
     update_function();
   }
@@ -276,12 +280,27 @@
                 <label for="team_members_only">{$LL.TOURNAMENTS.MANAGE.TEAM_MEMBERS_ONLY()}</label>
               </div>
               <div>
-                <select name="team_members_only" bind:value={data.team_members_only} disabled={is_edit}>
+                <select name="team_members_only" bind:value={data.team_members_only} on:change={updateData} disabled={is_edit}>
                   <option value={false}>{$LL.COMMON.NO()}</option>
                   <option value={true}>{$LL.COMMON.YES()}</option>
                 </select>
               </div>
             </div>
+            {#if data.team_members_only}
+              <div class="indented">
+                <div class="indented option">
+                  <div>
+                    <label for="sync_team_rosters">{$LL.TOURNAMENTS.MANAGE.SYNC_TEAM_ROSTERS()}</label>
+                  </div>
+                  <div>
+                    <select name="sync_team_rosters" bind:value={data.sync_team_rosters} on:change={updateData} disabled={is_edit}>
+                      <option value={false}>{$LL.COMMON.NO()}</option>
+                      <option value={true}>{$LL.COMMON.YES()}</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            {/if}
             <div class="indented option">
               <div>
                 <label for="min_representatives">{$LL.TOURNAMENTS.MANAGE.MIN_REPRESENTATIVES()}</label>
@@ -301,6 +320,24 @@
           {/if}
         </div>
       {/if}
+    </div>
+    <div class="indented">
+      <div class="indented">
+        <div class="indented option">
+          <div>
+            <label for="max_representatives">{$LL.TOURNAMENTS.MANAGE.MAX_REPRESENTATIVES()}</label>
+          </div>
+          <div>
+            <input
+              class="number"
+              type="number"
+              name="max_representatives"
+              bind:value={data.max_representatives}
+              min="0"
+            />
+          </div>
+        </div>
+      </div>
     </div>
   {/if}
   {#if !data.teams_allowed}

--- a/src/frontend/src/lib/components/tournaments/TournamentPlayerList.svelte
+++ b/src/frontend/src/lib/components/tournaments/TournamentPlayerList.svelte
@@ -223,7 +223,7 @@
         </td>
         <td>
           <PlayerName player_id={player.player_id} name={player.name} is_squad_captain={player.is_squad_captain} is_representative={player.is_representative}
-          is_bagger_clause={player.is_bagger_clause}/>
+          is_bagger_clause={player.is_bagger_clause} is_eligible={player.is_eligible}/>
         </td>
         {#if tournament.mii_name_required && exclude_invites}
           <td class="mobile-hide">{player.mii_name}</td>
@@ -268,7 +268,7 @@
                 </DropdownItem>
                 {#if !player.is_invite}
                   <DropdownItem on:click={() => makeCaptain(player)}>{$LL.TOURNAMENTS.REGISTRATIONS.MAKE_CAPTAIN()}</DropdownItem>
-                  {#if tournament.teams_only}
+                  {#if (tournament.min_representatives && tournament.min_representatives > 0) || (tournament.max_representatives && tournament.max_representatives > 0)}
                     {#if !player.is_representative}
                       <DropdownItem on:click={() => addRepresentative(player)}>{$LL.TOURNAMENTS.REGISTRATIONS.MAKE_REPRESENTATIVE()}</DropdownItem>
                     {:else}

--- a/src/frontend/src/lib/components/tournaments/TournamentPlayerList.svelte
+++ b/src/frontend/src/lib/components/tournaments/TournamentPlayerList.svelte
@@ -5,7 +5,7 @@
   import Flag from '../common/Flag.svelte';
   import type { UserInfo } from '$lib/types/user-info';
   import { user } from '$lib/stores/stores';
-  import PlayerName from './registration/PlayerName.svelte';
+  import TournamentPlayerName from './registration/TournamentPlayerName.svelte';
   import { ChevronDownSolid } from 'flowbite-svelte-icons';
   import Dropdown from '../common/Dropdown.svelte';
   import DropdownItem from '../common/DropdownItem.svelte';
@@ -222,8 +222,8 @@
           <Flag country_code={player.country_code}/>
         </td>
         <td>
-          <PlayerName player_id={player.player_id} name={player.name} is_squad_captain={player.is_squad_captain} is_representative={player.is_representative}
-          is_bagger_clause={player.is_bagger_clause} is_eligible={player.is_eligible}/>
+          <TournamentPlayerName player_id={player.player_id} name={player.name} is_squad_captain={player.is_squad_captain} is_representative={player.is_representative}
+          is_bagger_clause={player.is_bagger_clause} is_eligible={player.is_eligible} is_banned={player.is_banned}/>
         </td>
         {#if tournament.mii_name_required && exclude_invites}
           <td class="mobile-hide">{player.mii_name}</td>

--- a/src/frontend/src/lib/components/tournaments/TournamentRegistrations.svelte
+++ b/src/frontend/src/lib/components/tournaments/TournamentRegistrations.svelte
@@ -94,7 +94,7 @@
       </div>
       {#if tournament.is_squad}
         {#key [tournament_squads, show_all]}
-          <TournamentSquadList {tournament} squads={show_all ? tournament_squads : tournament_squads.slice(0, display_limit)} is_privileged={check_tournament_permission(user_info, tournament_permissions.manage_tournament_registrations,
+          <TournamentSquadList {tournament} bind:show_all={show_all} squads={show_all ? tournament_squads : tournament_squads.slice(0, display_limit)} is_privileged={check_tournament_permission(user_info, tournament_permissions.manage_tournament_registrations,
             tournament.id, tournament.series_id
           )}/>
         {/key}

--- a/src/frontend/src/lib/components/tournaments/TournamentRegistrations.svelte
+++ b/src/frontend/src/lib/components/tournaments/TournamentRegistrations.svelte
@@ -94,7 +94,7 @@
       </div>
       {#if tournament.is_squad}
         {#key [tournament_squads, show_all]}
-          <TournamentSquadList {tournament} bind:show_all={show_all} squads={show_all ? tournament_squads : tournament_squads.slice(0, display_limit)} is_privileged={check_tournament_permission(user_info, tournament_permissions.manage_tournament_registrations,
+          <TournamentSquadList {tournament} bind:show_all={show_all} squads={tournament_squads} is_privileged={check_tournament_permission(user_info, tournament_permissions.manage_tournament_registrations,
             tournament.id, tournament.series_id
           )}/>
         {/key}

--- a/src/frontend/src/lib/components/tournaments/TournamentSquadList.svelte
+++ b/src/frontend/src/lib/components/tournaments/TournamentSquadList.svelte
@@ -18,6 +18,10 @@
   export let squads: TournamentSquad[];
   export let is_privileged = false;
 
+  export let show_all = false;
+  let display_limit = 12;
+  let sorted_by = 'register-date';
+
   let edit_squad_dialog: EditSquadDialog;
   let add_player_dialog: AddPlayerToSquad;
   let manage_rosters_dialog: ManageSquadRosters;
@@ -82,6 +86,29 @@
       alert(`${$LL.TOURNAMENTS.REGISTRATIONS.UNREGISTER_SQUAD_FAILED()}: ${result['title']}`);
     }
   }
+
+  function sortSquadsByName() {
+    if(sorted_by !== 'name') {
+      squads.sort((a, b) => String(a.name).toLowerCase().localeCompare(String(b.name).toLowerCase()));
+    }
+    // sort in reverse if already sorted by name
+    else {
+      squads.reverse();
+    }
+    squads = squads;
+    sorted_by = 'name';
+  }
+
+  function sortSquadsByRegistrationDate() {
+    if(sorted_by !== 'register-date') {
+      squads.sort((a, b) => a.timestamp - b.timestamp);
+    }
+    else {
+      squads.reverse();
+    }
+    squads = squads;
+    sorted_by = 'register-date';
+  }
 </script>
 
 <Table>
@@ -105,7 +132,11 @@
         <th>{$LL.COMMON.TAG()}</th>
       {/if}
       {#if tournament.squad_name_required}
-        <th>{$LL.COMMON.NAME()}</th>
+        <th>
+          <button class="show-players" on:click={sortSquadsByName}>
+            {$LL.COMMON.NAME()}
+          </button>
+        </th>
       {/if}
       <th>
         {$LL.TOURNAMENTS.REGISTRATIONS.PLAYERS()}
@@ -114,66 +145,72 @@
         </button>
       </th>
       <th class="mobile-hide">{$LL.TOURNAMENTS.REGISTRATIONS.ELIGIBLE()}</th>
-      <th class="mobile-hide">{$LL.TOURNAMENTS.REGISTRATIONS.REGISTRATION_DATE()}</th>
+      <th class="mobile-hide">
+        <button class="show-players" on:click={sortSquadsByRegistrationDate}>
+          {$LL.TOURNAMENTS.REGISTRATIONS.REGISTRATION_DATE()}
+        </button>
+      </th>
       {#if is_privileged}
         <th/>
       {/if}
     </tr>
   </thead>
   <tbody>
-    {#each squads as squad, i}
-      <tr class="row-{i % 2}">
-        <td>{squad.id}</td>
-        {#if tournament.squad_tag_required}
-          <td>
-            <TagBadge tag={squad.tag} color={squad.color}/>
-          </td>
-        {/if}
-        {#if tournament.squad_name_required}
-          <td>
-            {#if squad.rosters.length}
-              <a href="/{$page.params.lang}/registry/teams/profile?id={squad.rosters[0].team_id}">
+    {#key [squads, show_all]}
+      {#each show_all ? squads : squads.slice(0, display_limit) as squad, i}
+        <tr class="row-{i % 2}">
+          <td>{squad.id}</td>
+          {#if tournament.squad_tag_required}
+            <td>
+              <TagBadge tag={squad.tag} color={squad.color}/>
+            </td>
+          {/if}
+          {#if tournament.squad_name_required}
+            <td>
+              {#if squad.rosters.length}
+                <a href="/{$page.params.lang}/registry/teams/profile?id={squad.rosters[0].team_id}">
+                  {squad.name}
+                </a>
+              {:else}
                 {squad.name}
-              </a>
-            {:else}
-              {squad.name}
-            {/if}
-          </td>
-        {/if}
-        <td
-          >{squad.players.filter((p) => !p.is_invite).length}
-          <button class="show-players" on:click={() => toggle_show_players(squad.id)}>
-            {squad_data[squad.id].display_players ? $LL.COMMON.HIDE_BUTTON() : $LL.COMMON.SHOW_BUTTON()}
-          </button></td
-        >
-        <td class="mobile-hide">
-          {is_squad_eligible(squad) ? $LL.COMMON.YES() : $LL.COMMON.NO()}
-        </td>
-        <td class="mobile-hide">{squad_data[squad.id].date.toLocaleString($locale, options)}</td>
-        {#if is_privileged}
-          <td>
-            <ChevronDownSolid class="cursor-pointer"/>
-            <Dropdown>
-              {#if !tournament.max_squad_size || squad.players.length < tournament.max_squad_size}
-                <DropdownItem on:click={() => add_player_dialog.open(squad)}>{$LL.TOURNAMENTS.REGISTRATIONS.ADD_PLAYER()}</DropdownItem>
               {/if}
-              <DropdownItem on:click={() => edit_squad_dialog.open(squad)}>{$LL.COMMON.EDIT()}</DropdownItem>
-              <DropdownItem on:click={() => unregisterSquad(squad)}>{$LL.TOURNAMENTS.REGISTRATIONS.REMOVE()}</DropdownItem>
-              {#if tournament.teams_allowed}
-                <DropdownItem on:click={() => manage_rosters_dialog.open(squad)}>{$LL.TOURNAMENTS.REGISTRATIONS.MANAGE_ROSTERS()}</DropdownItem>
-              {/if}
-            </Dropdown>
+            </td>
+          {/if}
+          <td
+            >{squad.players.filter((p) => !p.is_invite).length}
+            <button class="show-players" on:click={() => toggle_show_players(squad.id)}>
+              {squad_data[squad.id].display_players ? $LL.COMMON.HIDE_BUTTON() : $LL.COMMON.SHOW_BUTTON()}
+            </button></td
+          >
+          <td class="mobile-hide">
+            {is_squad_eligible(squad) ? $LL.COMMON.YES() : $LL.COMMON.NO()}
           </td>
-        {/if}
-      </tr>
-      {#if squad_data[squad.id].display_players}
-        <tr class="inner">
-          <td colspan="10">
-            <TournamentPlayerList {tournament} players={squad.players} {is_privileged}/>
-          </td>
+          <td class="mobile-hide">{squad_data[squad.id].date.toLocaleString($locale, options)}</td>
+          {#if is_privileged}
+            <td>
+              <ChevronDownSolid class="cursor-pointer"/>
+              <Dropdown>
+                {#if !tournament.max_squad_size || squad.players.length < tournament.max_squad_size}
+                  <DropdownItem on:click={() => add_player_dialog.open(squad)}>{$LL.TOURNAMENTS.REGISTRATIONS.ADD_PLAYER()}</DropdownItem>
+                {/if}
+                <DropdownItem on:click={() => edit_squad_dialog.open(squad)}>{$LL.COMMON.EDIT()}</DropdownItem>
+                <DropdownItem on:click={() => unregisterSquad(squad)}>{$LL.TOURNAMENTS.REGISTRATIONS.REMOVE()}</DropdownItem>
+                {#if tournament.teams_allowed}
+                  <DropdownItem on:click={() => manage_rosters_dialog.open(squad)}>{$LL.TOURNAMENTS.REGISTRATIONS.MANAGE_ROSTERS()}</DropdownItem>
+                {/if}
+              </Dropdown>
+            </td>
+          {/if}
         </tr>
-      {/if}
-    {/each}
+        {#if squad_data[squad.id].display_players}
+          <tr class="inner">
+            <td colspan="10">
+              <TournamentPlayerList {tournament} players={squad.players} {is_privileged}/>
+            </td>
+          </tr>
+        {/if}
+      {/each}
+    {/key}
   </tbody>
 </Table>
 

--- a/src/frontend/src/lib/components/tournaments/registration/ManageSquadRosters.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/ManageSquadRosters.svelte
@@ -140,6 +140,7 @@
     }
     div.add-roster {
         margin-top: 10px;
+        min-height: 200px;
     }
     div.button {
         margin-top: 5px;

--- a/src/frontend/src/lib/components/tournaments/registration/MyRegistration.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/MyRegistration.svelte
@@ -66,7 +66,7 @@
               <div>
                 {$LL.TOURNAMENTS.REGISTRATIONS.CHECKED_IN()}
               </div>
-              {#if reg.squad}
+              {#if tournament.min_players_checkin}
                 <div>
                   ({reg.squad.players.filter((p) => p.is_checked_in).length}/{tournament.min_players_checkin})
                 </div>

--- a/src/frontend/src/lib/components/tournaments/registration/PlayerName.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/PlayerName.svelte
@@ -3,16 +3,18 @@
     import { page } from "$app/stores";
     import RepresentativeBadge from "$lib/components/badges/RepresentativeBadge.svelte";
     import BaggerBadge from "$lib/components/badges/BaggerBadge.svelte";
+    import IneligibleBadge from "$lib/components/badges/IneligibleBadge.svelte";
 
     export let player_id: number;
     export let name: string;
     export let is_squad_captain: boolean = false;
     export let is_representative: boolean = false;
     export let is_bagger_clause: boolean = false;
+    export let is_eligible = true;
 </script>
 
-<div class="{is_squad_captain ? "captain" : is_representative ? "representative" : ""}">
-    <a href="/{$page.params.lang}/registry/players/profile?id={player_id}">
+<div class="{is_squad_captain ? "captain" : is_representative ? "representative" : ""} ">
+    <a href="/{$page.params.lang}/registry/players/profile?id={player_id}" class={!is_eligible ? "ineligible" : ""}>
         {name}
     </a>
     {#if is_squad_captain}
@@ -22,6 +24,9 @@
     {/if}
     {#if is_bagger_clause}
         <BaggerBadge/>
+    {/if}
+    {#if !is_eligible}
+        <IneligibleBadge/>
     {/if}
 </div>
 
@@ -36,5 +41,8 @@
     .representative {
         color: #ffdd99;
         font-weight: 700;
+    }
+    .ineligible {
+        opacity: 50%;
     }   
 </style>

--- a/src/frontend/src/lib/components/tournaments/registration/TeamTournamentRegister.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/TeamTournamentRegister.svelte
@@ -16,7 +16,7 @@
   import { ChevronDownSolid } from 'flowbite-svelte-icons';
   import Dropdown from '$lib/components/common/Dropdown.svelte';
   import DropdownItem from '$lib/components/common/DropdownItem.svelte';
-  import PlayerName from './PlayerName.svelte';
+  import TournamentPlayerName from './TournamentPlayerName.svelte';
   import RosterSearch from '$lib/components/common/RosterSearch.svelte';
   import type { Team } from '$lib/types/team';
   import LL from '$i18n/i18n-svelte';
@@ -238,8 +238,8 @@
                     <Flag country_code={player.country_code}/>
                   </td>
                   <td>
-                    <PlayerName player_id={player.player_id} name={player.name} is_squad_captain={player.is_captain}
-                    is_representative={player.is_representative} is_bagger_clause={player.is_bagger_clause}/>
+                    <TournamentPlayerName player_id={player.player_id} name={player.name} is_squad_captain={player.is_captain}
+                    is_representative={player.is_representative} is_bagger_clause={player.is_bagger_clause} is_banned={player.is_banned}/>
                   </td>
                   <td class="mobile-hide">
                     <FriendCodeDisplay friend_codes={player.friend_codes}/>

--- a/src/frontend/src/lib/components/tournaments/registration/TournamentInviteList.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/TournamentInviteList.svelte
@@ -171,12 +171,12 @@
     {#if user_info.player}
       <SoloTournamentFields {tournament} friend_codes={user_info.player.friend_codes} />
       <br />
-      <div>{$LL.TOURNAMENTS.REGISTRATIONS.SQUAD_ID}: {curr_invite?.id}</div>
+      <div>{$LL.TOURNAMENTS.REGISTRATIONS.SQUAD_ID()}: {curr_invite?.id}</div>
       {#if tournament.squad_tag_required}
-        <div>{$LL.TOURNAMENTS.REGISTRATIONS.SQUAD_TAG}: {curr_invite?.tag}</div>
+        <div>{$LL.TOURNAMENTS.REGISTRATIONS.SQUAD_TAG()}: {curr_invite?.tag}</div>
       {/if}
       {#if tournament.squad_name_required}
-        <div>{$LL.TOURNAMENTS.REGISTRATIONS.SQUAD_NAME}: {curr_invite?.name}</div>
+        <div>{$LL.TOURNAMENTS.REGISTRATIONS.SQUAD_NAME()}: {curr_invite?.name}</div>
       {/if}
       <br />
       <div>

--- a/src/frontend/src/lib/components/tournaments/registration/TournamentPlayerName.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/TournamentPlayerName.svelte
@@ -7,6 +7,7 @@
 
     export let player_id: number;
     export let name: string;
+    export let is_banned: boolean = false;
     export let is_squad_captain: boolean = false;
     export let is_representative: boolean = false;
     export let is_bagger_clause: boolean = false;
@@ -14,7 +15,7 @@
 </script>
 
 <div class="{is_squad_captain ? "captain" : is_representative ? "representative" : ""} ">
-    <a href="/{$page.params.lang}/registry/players/profile?id={player_id}" class={!is_eligible ? "ineligible" : ""}>
+    <a href="/{$page.params.lang}/registry/players/profile?id={player_id}" class="{is_banned ? "banned_name" : ""} {!is_eligible ? "ineligible" : ""}">
         {name}
     </a>
     {#if is_squad_captain}
@@ -44,5 +45,9 @@
     }
     .ineligible {
         opacity: 50%;
-    }   
+    }
+    .banned_name {
+        opacity: 0.7;
+        text-decoration: line-through;
+    }
 </style>

--- a/src/frontend/src/lib/components/tournaments/templates/TemplateList.svelte
+++ b/src/frontend/src/lib/components/tournaments/templates/TemplateList.svelte
@@ -45,7 +45,7 @@
       {/if}
     {/if}
     {#if series_id}
-      <Button href="/{$page.params.lang}/tournaments/series/details?id={series_id}">{$LL.TOURNAMENTS.TEMPLATES.CREATE_TEMPLATE()}</Button>
+      <Button href="/{$page.params.lang}/tournaments/series/details?id={series_id}">{$LL.TOURNAMENTS.SERIES.BACK_TO_SERIES()}</Button>
     {/if}
   </div>
   <Table>

--- a/src/frontend/src/lib/types/player-transfer.ts
+++ b/src/frontend/src/lib/types/player-transfer.ts
@@ -1,4 +1,5 @@
 export type PlayerTransferItem = {
+  id: number;
   team_id: number;
   team_name: string;
   game: string;
@@ -7,6 +8,7 @@ export type PlayerTransferItem = {
   leave_date: number | null;
   is_bagger_clause: boolean;
   roster_name: string | null;
+  is_hidden: boolean;
 };
 
 export type PlayerTransferHistory = {

--- a/src/frontend/src/lib/types/player.ts
+++ b/src/frontend/src/lib/types/player.ts
@@ -4,12 +4,12 @@ export type PlayerBasic = {
   id: number;
   name: string;
   country_code: string;
+  is_banned: boolean;
 };
 
 export type Player = PlayerBasic & {
   is_hidden: boolean;
   is_shadow: boolean;
-  is_banned: boolean;
   join_date: number;
   discord: Discord | null;
 };

--- a/src/frontend/src/lib/types/tournament-player.ts
+++ b/src/frontend/src/lib/types/tournament-player.ts
@@ -13,6 +13,7 @@ export type TournamentPlayer = {
   can_host: boolean;
   name: string;
   country_code: string;
+  is_banned: boolean;
   discord: Discord | null;
   selected_fc_id: number | null;
   friend_codes: FriendCode[];

--- a/src/frontend/src/lib/types/tournament-player.ts
+++ b/src/frontend/src/lib/types/tournament-player.ts
@@ -8,6 +8,7 @@ export type TournamentPlayer = {
   timestamp: number;
   is_checked_in: boolean;
   is_approved: boolean;
+  is_eligible: boolean;
   mii_name: string | null;
   can_host: boolean;
   name: string;

--- a/src/frontend/src/lib/types/tournament.ts
+++ b/src/frontend/src/lib/types/tournament.ts
@@ -21,6 +21,7 @@ export type TournamentBasic = {
   teams_only: boolean;
   team_members_only: boolean;
   min_representatives: number | null;
+  max_representatives: number | null;
   host_status_required: boolean;
   mii_name_required: boolean;
   require_single_fc: boolean;
@@ -42,6 +43,7 @@ export type TournamentBasic = {
   series_stats_include: boolean;
   verified_fc_required: boolean;
   bagger_clause_enabled: boolean;
+  sync_team_rosters: boolean;
 };
 
 export type Tournament = {

--- a/src/frontend/src/routes/[lang]/moderator/alt_detection/+page.svelte
+++ b/src/frontend/src/routes/[lang]/moderator/alt_detection/+page.svelte
@@ -22,6 +22,8 @@
 
     let type: string | null = null;
     let exclude_fingerprints = true;
+    let from: string | null = null;
+    let to: string | null = null;
 
     async function fetchData() {
         let url = `/api/moderator/altFlags?page=${currentPage}`;
@@ -30,6 +32,12 @@
         }
         if(exclude_fingerprints) {
             url += `&exclude_fingerprints=true`
+        }
+        if(from) {
+            url += `&from_date=${Date.parse(String(from)) / 1000}`
+        }
+        if(to) {
+            url += `&to_date=${Date.parse(String(to)) / 1000}`
         }
         const res = await fetch(url);
         if(res.status === 200) {
@@ -54,7 +62,7 @@
     {#if check_permission(user_info, permissions.view_alt_flags)}
         <Section header={$LL.MODERATOR.ALT_DETECTION.ALT_FLAGS()}>
             {#if totalFlags}
-                <div>
+                <div class="flex gap-4 items-center">
                     <select bind:value={type} on:change={filter}>
                         <option value={null}>
                             All Flags
@@ -76,6 +84,14 @@
                         <option value={true}>{$LL.MODERATOR.ALT_DETECTION.EXCLUDE_FINGERPRINTS()}</option>
                         <option value={false}>{$LL.MODERATOR.ALT_DETECTION.INCLUDE_FINGERPRINTS()}</option>
                     </select>
+                    <div class="flex gap-4 items-center">
+                        {$LL.COMMON.FROM()}
+                        <input name="from" type="date" bind:value={from} on:change={filter}/>
+                    </div>
+                    <div class="flex gap-4 items-center">
+                        {$LL.COMMON.TO()}
+                        <input name="to" type="date" bind:value={to} on:change={filter}/>
+                    </div>
                 </div>
                 <PageNavigation bind:currentPage={currentPage} bind:totalPages={totalPages} refresh_function={fetchData}/>
                 {#key flags}

--- a/src/frontend/src/routes/[lang]/moderator/alt_detection/+page.svelte
+++ b/src/frontend/src/routes/[lang]/moderator/alt_detection/+page.svelte
@@ -73,8 +73,8 @@
                         </option>
                     </select>
                     <select bind:value={exclude_fingerprints} on:change={fetchData}>
-                        <option value={true}>Exclude Fingerprints</option>
-                        <option value={false}>Include Fingerprints</option>
+                        <option value={true}>{$LL.MODERATOR.ALT_DETECTION.EXCLUDE_FINGERPRINTS()}</option>
+                        <option value={false}>{$LL.MODERATOR.ALT_DETECTION.INCLUDE_FINGERPRINTS()}</option>
                     </select>
                 </div>
                 <PageNavigation bind:currentPage={currentPage} bind:totalPages={totalPages} refresh_function={fetchData}/>

--- a/src/frontend/src/routes/[lang]/moderator/player_claims/+page.svelte
+++ b/src/frontend/src/routes/[lang]/moderator/player_claims/+page.svelte
@@ -99,13 +99,13 @@
                         <tr class="row-{i % 2}">
                             <td><Flag country_code={claim.player.country_code}/></td>
                             <td>
-                                <a href="{$page.params.lang}/registry/players/profile?id={claim.player.id}">
+                                <a href="/{$page.params.lang}/registry/players/profile?id={claim.player.id}">
                                     {claim.player.name}
                                 </a>
                             </td>
                             <td><Flag country_code={claim.claimed_player.country_code}/></td>
                             <td>
-                                <a href="{$page.params.lang}/registry/players/profile?id={claim.claimed_player.id}">
+                                <a href="/{$page.params.lang}/registry/players/profile?id={claim.claimed_player.id}">
                                     {claim.claimed_player.name}
                                 </a>
                             </td>

--- a/src/frontend/src/routes/[lang]/tournaments/edit/+page.svelte
+++ b/src/frontend/src/routes/[lang]/tournaments/edit/+page.svelte
@@ -45,6 +45,7 @@
         teams_only: tournament.teams_only,
         team_members_only: tournament.team_members_only,
         min_representatives: tournament.min_representatives,
+        max_representatives: tournament.max_representatives,
         host_status_required: tournament.host_status_required,
         mii_name_required: tournament.mii_name_required,
         require_single_fc: tournament.require_single_fc,
@@ -66,6 +67,7 @@
         series_stats_include: tournament.series_stats_include,
         verified_fc_required: tournament.verified_fc_required,
         bagger_clause_enabled: tournament.bagger_clause_enabled,
+        sync_team_rosters: tournament.sync_team_rosters,
         logo_file: null,
         remove_logo: false,
       };


### PR DESCRIPTION
- Support for mods to mark entries in player registration history as hidden
- Style color select options with the background of each color
- Fix visual bug with checkins: shows 1/null for solo tournaments after you've checked in
- Add sorting by squad name and registration date for squad tournament registrations
- Automatically check people in for tournaments who register/accept invite while checkins are open
- Show whether players are banned or not on tournament pages and other misc pages
- Change max number of leaders per team to be 4 per roster instead of 4 per team
- Allow for representatives in squad + team tournaments
- Add value for max representatives so people can't make their whole team representatives for a tournament
- Support for searching by Discord ID in player search
- Exclude invites from player tournament history
- Add exclude fingerprints option to player alt flags endpoint
- Add roster filter to team tournament history
- Fix "not authorized to grant role" message for site staff when editing bans
- Add date filter to alt flags page
- Fix height of "manage rosters" modal in team tournaments
- Automatically close registrations for tournaments where the registration deadline has passed
- Add option for team tournament squads to be "locked" after registration deadline (so don't remove players from squad when they transfer)
- Instead of removing tournament players from their squad if they leave their team, mark them as ineligible and display it on the tournament page
- Fix bad links in player claim page
- Fixed the text on the "Back to Series" button on the "Manage Templates" series page which previously said "Create Template"
- Show mode in Old Roster dropdown for Manually Transfer Player page
- Show player ID number when hovering over a player when using the player search dropdown component
- Show roster name when hovering over a team tag on team transfer list
