### PR TITLE
feat: include timezone for tournament registration

### DIFF
--- a/src/frontend/src/lib/components/tournaments/TournamentInfo.svelte
+++ b/src/frontend/src/lib/components/tournaments/TournamentInfo.svelte
@@ -31,9 +31,12 @@
     ? new Date(tournament.registration_deadline * 1000)
     : null;
   const options: Intl.DateTimeFormatOptions = {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-    hour12: true,
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZoneName: 'short',
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
https://github.com/MarioKartCentral/MarioKartCentral/issues/255

Uses 24-hour for Europe/Japan; 12-hour for US (per locale)

<img width="547" height="134" alt="image" src="https://github.com/user-attachments/assets/09fabee2-98b6-45d4-9b68-cddc5a13341c" />

<img width="547" height="134" alt="image" src="https://github.com/user-attachments/assets/2a8b001d-f3f6-4ff7-8a14-b6f44f491a59" />
<img width="547" height="134" alt="image" src="https://github.com/user-attachments/assets/6580d042-c94e-441f-b227-7fc1a0625efe" />


