### PR TITLE
Update tournament registration API endpoints

### DIFF
--- a/src/backend/api/endpoints/tournament_registration.py
+++ b/src/backend/api/endpoints/tournament_registration.py
@@ -95,8 +95,8 @@ async def force_create_squad(request: Request, body: ForceCreateSquadRequestData
 async def edit_squad(request: Request, body: EditSquadRequestData) -> JSONResponse:
     tournament_id = request.path_params['tournament_id']
     command = EditSquadCommand(tournament_id, body.registration_id, body.squad_name, body.squad_tag, body.squad_color, body.is_registered, body.is_approved)
-    await handle(command)
-    return JSONResponse({})
+    squad_update = await handle(command)
+    return JSONResponse(squad_update)
 
 @bind_request_body(EditMySquadRequestData)
 @check_word_filter
@@ -107,8 +107,8 @@ async def edit_my_squad(request: Request, body: EditMySquadRequestData) -> JSONR
     command = CheckSquadCaptainPermissionsCommand(tournament_id, body.registration_id, captain_player_id)
     await handle(command)
     command = EditSquadCommand(tournament_id, body.registration_id, body.squad_name, body.squad_tag, body.squad_color, True, None)
-    await handle(command)
-    return JSONResponse({})
+    squad_update = await handle(command)
+    return JSONResponse(squad_update)
 
 # used when the captain of a squad invites a player to their squad.
 # use force_register_player in tournament staff contexts

--- a/src/backend/api/endpoints/tournament_registration.py
+++ b/src/backend/api/endpoints/tournament_registration.py
@@ -128,8 +128,8 @@ async def invite_player(request: Request, body: InvitePlayerRequestData) -> JSON
     command = CheckSquadCaptainPermissionsCommand(tournament_id, body.registration_id, captain_player_id)
     await handle(command)
     command = RegisterPlayerCommand(body.player_id, tournament_id, body.registration_id, False, False, None, False, True, None, body.is_representative, body.is_bagger_clause, False, False)
-    await handle(command)
-    return JSONResponse({}, background=BackgroundTask(notify))
+    player_registration = await handle(command)
+    return JSONResponse(player_registration, background=BackgroundTask(notify))
 
 # endpoint used when a user registers themself for a tournament
 @bind_request_body(RegisterPlayerRequestData)
@@ -143,8 +143,8 @@ async def register_me(request: Request, body: RegisterPlayerRequestData) -> JSON
     if body.can_host and not player_host_permission:
         raise Problem("User does not have permission to register as a host", status=401)
     command = RegisterPlayerCommand(player_id, tournament_id, None, False, False, body.mii_name, body.can_host, False, body.selected_fc_id, False, False, False, False)
-    await handle(command)
-    return JSONResponse({})
+    player_registration = await handle(command)
+    return JSONResponse(player_registration)
 
 # endpoint used when a tournament staff registers another player for a tournament (requires permissions)
 @bind_request_body(ForceRegisterPlayerRequestData)
@@ -166,8 +166,8 @@ async def force_register_player(request: Request, body: ForceRegisterPlayerReque
     tournament_id = request.path_params['tournament_id']
     command = RegisterPlayerCommand(body.player_id, tournament_id, body.registration_id, body.is_squad_captain, body.is_checked_in, 
         body.mii_name, body.can_host, body.is_invite, body.selected_fc_id, body.is_representative, body.is_bagger_clause, body.is_approved, True)
-    await handle(command)
-    return JSONResponse({}, background=BackgroundTask(notify, tournament_id=tournament_id))
+    player_registration = await handle(command)
+    return JSONResponse(player_registration, background=BackgroundTask(notify, tournament_id=tournament_id))
 
 @bind_request_body(EditPlayerRegistrationRequestData)
 @check_word_filter

--- a/src/backend/api/endpoints/tournament_registration.py
+++ b/src/backend/api/endpoints/tournament_registration.py
@@ -292,7 +292,7 @@ async def staff_unregister(request: Request, body: StaffUnregisterPlayerRequestD
 
 @bind_request_body(MakeCaptainRequestData)
 @require_tournament_permission(tournament_permissions.REGISTER_TOURNAMENT, check_denied_only=True)
-async def change_squad_captain(request: Request, body: MakeCaptainRequestData) -> JSONResponse:
+async def change_squad_captain(request: Request, body: MakeCaptainRequestData) -> Response:
     async def notify():
         user_id = await handle(GetUserIdFromPlayerIdCommand(body.player_id))
         if user_id is None:
@@ -307,11 +307,11 @@ async def change_squad_captain(request: Request, body: MakeCaptainRequestData) -
     await handle(command)
     command = ChangeSquadCaptainCommand(tournament_id, body.registration_id, body.player_id)
     await handle(command)
-    return JSONResponse({}, background=BackgroundTask(notify))
+    return Response(status_code=204, background=BackgroundTask(notify))
 
 @bind_request_body(MakeCaptainRequestData)
 @require_tournament_permission(tournament_permissions.REGISTER_TOURNAMENT, check_denied_only=True)
-async def add_team_representative(request: Request, body: MakeCaptainRequestData) -> JSONResponse:
+async def add_team_representative(request: Request, body: MakeCaptainRequestData) -> Response:
     async def notify():
         user_id = await handle(GetUserIdFromPlayerIdCommand(body.player_id))
         if user_id is None:
@@ -326,7 +326,7 @@ async def add_team_representative(request: Request, body: MakeCaptainRequestData
     await handle(command)
     command = AddRepresentativeCommand(tournament_id, body.registration_id, body.player_id)
     await handle(command)
-    return JSONResponse({}, background=BackgroundTask(notify))
+    return Response(status_code=204, background=BackgroundTask(notify))
 
 @bind_request_body(MakeCaptainRequestData)
 @require_tournament_permission(tournament_permissions.REGISTER_TOURNAMENT, check_denied_only=True)
@@ -403,12 +403,12 @@ async def my_registration(request: Request) -> JSONResponse:
 
 @bind_request_body(TournamentCheckinRequestData)
 @require_tournament_permission(tournament_permissions.REGISTER_TOURNAMENT, check_denied_only=True)
-async def toggle_checkin(request: Request, body: TournamentCheckinRequestData) -> JSONResponse:
+async def toggle_checkin(request: Request, body: TournamentCheckinRequestData) -> Response:
     tournament_id = request.path_params['tournament_id']
     player_id = request.state.user.player_id
     command = TogglePlayerCheckinCommand(tournament_id, body.registration_id, player_id)
     await handle(command)
-    return JSONResponse({})
+    return Response(status_code=204)
 
 @bind_request_body(AddRemoveRosterRequestData)
 @require_tournament_permission(tournament_permissions.REGISTER_TOURNAMENT, check_denied_only=True)

--- a/src/backend/api/endpoints/tournament_registration.py
+++ b/src/backend/api/endpoints/tournament_registration.py
@@ -1,4 +1,5 @@
 from starlette.requests import Request
+from starlette.responses import Response
 from starlette.routing import Route
 from starlette.background import BackgroundTask
 from api.auth import require_logged_in, require_tournament_permission, check_tournament_visiblity
@@ -225,7 +226,7 @@ async def accept_invite(request: Request, body: AcceptInviteRequestData) -> JSON
 
 @bind_request_body(DeclineInviteRequestData)
 @require_logged_in()
-async def decline_invite(request: Request, body: DeclineInviteRequestData) -> JSONResponse:
+async def decline_invite(request: Request, body: DeclineInviteRequestData) -> Response:
     async def notify():
         data = await handle(GetNotificationSquadDataCommand(tournament_id, body.registration_id))
         player_name = await handle(GetPlayerNameCommand(player_id))
@@ -236,12 +237,12 @@ async def decline_invite(request: Request, body: DeclineInviteRequestData) -> JS
     player_id = request.state.user.player_id
     command = UnregisterPlayerCommand(tournament_id, body.registration_id, player_id, False)
     await handle(command)
-    return JSONResponse({}, background=BackgroundTask(notify))
+    return Response(status_code=204, background=BackgroundTask(notify))
 
 # used when a squad captain wants to remove a member from their squad
 @bind_request_body(KickSquadPlayerRequestData)
 @require_tournament_permission(tournament_permissions.REGISTER_TOURNAMENT, check_denied_only=True)
-async def remove_player_from_squad(request: Request, body: KickSquadPlayerRequestData) -> JSONResponse:
+async def remove_player_from_squad(request: Request, body: KickSquadPlayerRequestData) -> Response:
     async def notify():
         user_id = await handle(GetUserIdFromPlayerIdCommand(body.player_id))
         if user_id is None:
@@ -256,22 +257,22 @@ async def remove_player_from_squad(request: Request, body: KickSquadPlayerReques
     await handle(command)
     command = UnregisterPlayerCommand(tournament_id, body.registration_id, body.player_id, False)
     await handle(command)
-    return JSONResponse({}, background=BackgroundTask(notify))
+    return Response(status_code=204, background=BackgroundTask(notify))
 
 # used when a player unregisters themself from the tournament
 @bind_request_body(UnregisterPlayerRequestData)
 @require_logged_in()
-async def unregister_me(request: Request, body: UnregisterPlayerRequestData) -> JSONResponse:
+async def unregister_me(request: Request, body: UnregisterPlayerRequestData) -> Response:
     tournament_id = request.path_params['tournament_id']
     player_id = request.state.user.player_id
     command = UnregisterPlayerCommand(tournament_id, body.registration_id, player_id, False)
     await handle(command)
-    return JSONResponse({})
+    return Response(status_code=204)
 
 # used when a staff member force removes a player from the tournament
 @bind_request_body(StaffUnregisterPlayerRequestData)
 @require_tournament_permission(tournament_permissions.MANAGE_TOURNAMENT_REGISTRATIONS)
-async def staff_unregister(request: Request, body: StaffUnregisterPlayerRequestData) -> JSONResponse:
+async def staff_unregister(request: Request, body: StaffUnregisterPlayerRequestData) -> Response:
     @dispatch_notification_if(tournament_is_viewable)
     async def notify(tournament_id: int):
         user_id = await handle(GetUserIdFromPlayerIdCommand(body.player_id))
@@ -287,7 +288,7 @@ async def staff_unregister(request: Request, body: StaffUnregisterPlayerRequestD
     tournament_id = request.path_params['tournament_id']
     command = UnregisterPlayerCommand(tournament_id, body.registration_id, body.player_id, True)
     await handle(command)
-    return JSONResponse({}, background=BackgroundTask(notify, tournament_id=tournament_id))
+    return Response(status_code=204, background=BackgroundTask(notify, tournament_id=tournament_id))
 
 @bind_request_body(MakeCaptainRequestData)
 @require_tournament_permission(tournament_permissions.REGISTER_TOURNAMENT, check_denied_only=True)
@@ -329,7 +330,7 @@ async def add_team_representative(request: Request, body: MakeCaptainRequestData
 
 @bind_request_body(MakeCaptainRequestData)
 @require_tournament_permission(tournament_permissions.REGISTER_TOURNAMENT, check_denied_only=True)
-async def remove_team_representative(request: Request, body: MakeCaptainRequestData) -> JSONResponse:
+async def remove_team_representative(request: Request, body: MakeCaptainRequestData) -> Response:
     async def notify():
         user_id = await handle(GetUserIdFromPlayerIdCommand(body.player_id))
         if user_id is None:
@@ -344,22 +345,22 @@ async def remove_team_representative(request: Request, body: MakeCaptainRequestD
     await handle(command)
     command = RemoveRepresentativeCommand(tournament_id, body.registration_id, body.player_id)
     await handle(command)
-    return JSONResponse({}, background=BackgroundTask(notify))
+    return Response(status_code=204, background=BackgroundTask(notify))
 
 @bind_request_body(UnregisterSquadRequestData)
 @require_logged_in()
-async def unregister_squad(request: Request, body: UnregisterSquadRequestData) -> JSONResponse:
+async def unregister_squad(request: Request, body: UnregisterSquadRequestData) -> Response:
     tournament_id = request.path_params['tournament_id']
     captain_player_id = request.state.user.player_id
     command = CheckSquadCaptainPermissionsCommand(tournament_id, body.registration_id, captain_player_id)
     await handle(command)
     command = UnregisterSquadCommand(tournament_id, body.registration_id)
     await handle(command)
-    return JSONResponse({})
+    return Response(status_code=204)
 
 @bind_request_body(UnregisterSquadRequestData)
 @require_tournament_permission(tournament_permissions.MANAGE_TOURNAMENT_REGISTRATIONS)
-async def force_unregister_squad(request: Request, body: UnregisterSquadRequestData) -> JSONResponse:
+async def force_unregister_squad(request: Request, body: UnregisterSquadRequestData) -> Response:
     @dispatch_notification_if(tournament_is_viewable)
     async def notify(tournament_id: int):
         await handle(DispatchNotificationCommand([data.captain_user_id], notifications.STAFF_UNREGISTER_TEAM, {'tournament_name': data.tournament_name}, f'/tournaments/details?id={tournament_id}', notifications.WARNING))
@@ -373,7 +374,7 @@ async def force_unregister_squad(request: Request, body: UnregisterSquadRequestD
     
     command = UnregisterSquadCommand(tournament_id, body.registration_id)
     await handle(command)
-    return JSONResponse({}, background=BackgroundTask(notify, tournament_id=tournament_id))
+    return Response(status_code=204, background=BackgroundTask(notify, tournament_id=tournament_id))
 
 async def view_squad(request: Request) -> JSONResponse:
     tournament_id = request.path_params['tournament_id']
@@ -420,12 +421,12 @@ async def add_roster_to_squad(request: Request, body: AddRemoveRosterRequestData
 
 @bind_request_body(AddRemoveRosterRequestData)
 @require_tournament_permission(tournament_permissions.REGISTER_TOURNAMENT, check_denied_only=True)
-async def remove_roster_from_squad(request: Request, body: AddRemoveRosterRequestData) -> JSONResponse:
+async def remove_roster_from_squad(request: Request, body: AddRemoveRosterRequestData) -> Response:
     tournament_id = request.path_params['tournament_id']
     player_id = request.state.user.player_id
     command = RemoveRosterFromSquadCommand(tournament_id, body.registration_id, body.roster_id, player_id)
     await handle(command)
-    return JSONResponse({})
+    return Response(status_code=204)
 
 @bind_request_body(AddRemoveRosterRequestData)
 @require_tournament_permission(tournament_permissions.MANAGE_TOURNAMENT_REGISTRATIONS)
@@ -437,11 +438,11 @@ async def force_add_roster_to_squad(request: Request, body: AddRemoveRosterReque
 
 @bind_request_body(AddRemoveRosterRequestData)
 @require_tournament_permission(tournament_permissions.MANAGE_TOURNAMENT_REGISTRATIONS)
-async def force_remove_roster_from_squad(request: Request, body: AddRemoveRosterRequestData) -> JSONResponse:
+async def force_remove_roster_from_squad(request: Request, body: AddRemoveRosterRequestData) -> Response:
     tournament_id = request.path_params['tournament_id']
     command = RemoveRosterFromSquadCommand(tournament_id, body.registration_id, body.roster_id, None, True)
     await handle(command)
-    return JSONResponse({})
+    return Response(status_code=204)
 
 routes = [
     Route('/api/tournaments/{tournament_id:int}/register', register_me, methods=['POST']),

--- a/src/backend/api/endpoints/tournament_registration.py
+++ b/src/backend/api/endpoints/tournament_registration.py
@@ -27,8 +27,10 @@ async def create_my_squad(request: Request, body: CreateSquadRequestData) -> JSO
         raise Problem("User does not have permission to register as a host", status=401)
     command = CreateSquadCommand(body.squad_name, body.squad_tag, body.squad_color, player_id, tournament_id, 
         False, body.is_bagger_clause, body.mii_name, body.can_host, body.selected_fc_id, False, is_privileged=False)
-    await handle(command)
-    return JSONResponse({})
+    registration_id = await handle(command)
+    return JSONResponse({'registration_id': registration_id}, status_code=201, headers={
+        'Location': f'/api/tournaments/{tournament_id}/squads/{registration_id}'
+    })
 
 # endpoint used when a non-moderator user registers a team for a tournament
 @bind_request_body(RegisterTeamRequestData)
@@ -39,8 +41,10 @@ async def register_my_team(request: Request, body: RegisterTeamRequestData) -> J
     player_id = request.state.user.player_id
     command = RegisterTeamTournamentCommand(tournament_id, body.squad_name, body.squad_tag, body.squad_color,
                                             player_id, body.roster_ids, body.players, False)
-    await handle(command)
-    return JSONResponse({})
+    registration_id = await handle(command)
+    return JSONResponse({'registration_id': registration_id}, status_code=201, headers={
+        'Location': f'/api/tournaments/{tournament_id}/squads/{registration_id}'
+    })
 
 @bind_request_body(RegisterTeamRequestData)
 @check_word_filter
@@ -57,7 +61,10 @@ async def force_register_team(request: Request, body: RegisterTeamRequestData) -
     command = RegisterTeamTournamentCommand(tournament_id, body.squad_name, body.squad_tag, body.squad_color,
                                             player_id, body.roster_ids, body.players, True, is_privileged=True)
     registration_id = await handle(command)
-    return JSONResponse({}, background=BackgroundTask(notify, tournament_id=tournament_id))
+    return JSONResponse({'registration_id': registration_id}, status_code=201, headers={
+        'Location': f'/api/tournaments/{tournament_id}/squads/{registration_id}'},
+        background=BackgroundTask(notify, tournament_id=tournament_id)
+    )
 
 # endpoint used when a tournament staff creates a squad with another user in it
 @bind_request_body(ForceCreateSquadRequestData)
@@ -75,8 +82,11 @@ async def force_create_squad(request: Request, body: ForceCreateSquadRequestData
     tournament_id = request.path_params['tournament_id']
     command = CreateSquadCommand(body.squad_name, body.squad_tag, body.squad_color, body.player_id, tournament_id, 
         body.is_checked_in, body.is_bagger_clause, body.mii_name, body.can_host, body.selected_fc_id, body.is_approved, is_privileged=True)
-    await handle(command)
-    return JSONResponse({}, background=BackgroundTask(notify, tournament_id=tournament_id))
+    registration_id = await handle(command)
+    return JSONResponse({'registration_id': registration_id}, status_code=201, headers={
+        'Location': f'/api/tournaments/{tournament_id}/squads/{registration_id}'},
+        background=BackgroundTask(notify, tournament_id=tournament_id)
+    )
 
 @bind_request_body(EditSquadRequestData)
 @check_word_filter

--- a/src/backend/api/endpoints/tournament_registration.py
+++ b/src/backend/api/endpoints/tournament_registration.py
@@ -184,8 +184,8 @@ async def edit_registration(request: Request, body: EditPlayerRegistrationReques
     command = EditPlayerRegistrationCommand(tournament_id, body.registration_id, body.player_id, body.mii_name, body.can_host,
         body.is_invite, body.is_checked_in, body.is_squad_captain, body.selected_fc_id, body.is_representative, 
         body.is_bagger_clause, body.is_approved, True)
-    await handle(command)
-    return JSONResponse({}, background=BackgroundTask(notify))
+    registration_update = await handle(command)
+    return JSONResponse(registration_update, background=BackgroundTask(notify))
 
 @bind_request_body(EditMyRegistrationRequestData)
 @check_word_filter
@@ -199,8 +199,8 @@ async def edit_my_registration(request: Request, body: EditMyRegistrationRequest
         raise Problem("User does not have permission to register as a host", status=401)
     command = EditPlayerRegistrationCommand(tournament_id, body.registration_id, player_id, body.mii_name, body.can_host, False, None, None, body.selected_fc_id,
                                             None, None, None, False)
-    await handle(command)
-    return JSONResponse({})
+    registration_update = await handle(command)
+    return JSONResponse(registration_update)
 
 @bind_request_body(AcceptInviteRequestData)
 @check_word_filter
@@ -221,8 +221,8 @@ async def accept_invite(request: Request, body: AcceptInviteRequestData) -> JSON
     
     command = EditPlayerRegistrationCommand(tournament_id, body.registration_id, player_id, body.mii_name, body.can_host,
         False, False, False, body.selected_fc_id, None, None, None, False)
-    await handle(command)
-    return JSONResponse({}, background=BackgroundTask(notify))
+    registration_update = await handle(command)
+    return JSONResponse(registration_update, background=BackgroundTask(notify))
 
 @bind_request_body(DeclineInviteRequestData)
 @require_logged_in()

--- a/src/backend/common/data/commands/tournaments/registrations.py
+++ b/src/backend/common/data/commands/tournaments/registrations.py
@@ -7,7 +7,7 @@ from common.data.db import DBWrapper
 from common.data.models import *
 
 @dataclass
-class RegisterPlayerCommand(Command[None]):
+class RegisterPlayerCommand(Command[SquadPlayerDetails]):
     player_id: int
     tournament_id: int
     registration_id: int | None
@@ -22,16 +22,16 @@ class RegisterPlayerCommand(Command[None]):
     is_approved: bool
     is_privileged: bool #if True, bypasses check for tournament registrations being open
 
-    async def handle(self, db_wrapper: DBWrapper) -> None:
+    async def handle(self, db_wrapper: DBWrapper) -> SquadPlayerDetails:
         timestamp = int(datetime.now(timezone.utc).timestamp())
         async with db_wrapper.connect() as db:
             # check if registrations are open and if mii name is required
-            async with db.execute("SELECT is_squad, max_squad_size, mii_name_required, registrations_open, team_members_only, require_single_fc, bagger_clause_enabled, checkins_open FROM tournaments WHERE id = ?",
+            async with db.execute("SELECT game, is_squad, max_squad_size, mii_name_required, registrations_open, team_members_only, require_single_fc, bagger_clause_enabled, checkins_open FROM tournaments WHERE id = ?",
                                   (self.tournament_id,)) as cursor:
                 row = await cursor.fetchone()
                 if row is None:
                     raise Problem("Tournament not found", status=404)
-                is_squad, max_squad_size, mii_name_required, registrations_open, team_members_only, require_single_fc, bagger_clause_enabled, checkins_open = row
+                game, is_squad, max_squad_size, mii_name_required, registrations_open, team_members_only, require_single_fc, bagger_clause_enabled, checkins_open = row
                 if bool(is_squad) and self.registration_id is None:
                     raise Problem("Players may not register alone for squad tournaments", status=400)
                 if not bool(is_squad) and self.registration_id is not None:
@@ -53,12 +53,24 @@ class RegisterPlayerCommand(Command[None]):
                 if not require_single_fc:
                     selected_fc_id = None
                     
-            # check if player exists if we are force-registering them
-            if self.is_privileged:
-                async with db.execute("SELECT id FROM players WHERE id = ?", (self.player_id,)) as cursor:
-                    row = await cursor.fetchone()
-                    if row is None:
-                        raise Problem("Player not found", status=404)
+
+            async with db.execute("SELECT name, country_code, is_banned FROM players WHERE id = ?", (self.player_id,)) as cursor:
+                db_player = await cursor.fetchone()
+                if db_player is None:
+                    raise Problem("Player not found", status=404)
+                player_name, player_country_code, player_is_banned = db_player
+            
+            user_id = None
+            discord = None
+            async with db.execute("SELECT id from users WHERE player_id = ?", (self.player_id,)) as cursor:
+                user_id = cursor.lastrowid
+
+            if user_id:
+                async with db.execute("SELECT discord_id, username, discriminator, global_name, avatar FROM user_discords WHERE user_id = ?",
+                                    (user_id,)) as cursor:
+                    db_discord = await cursor.fetchone()
+                    if db_discord is not None:
+                        discord = Discord(*db_discord)
             
             registration_id = self.registration_id
             # check if squad exists and if we are using the squad's tag in our mii name
@@ -114,11 +126,29 @@ class RegisterPlayerCommand(Command[None]):
             # checkin player if they're not being invited to the tournament
             is_checked_in = True if bool(checkins_open) and not self.is_invite else self.is_checked_in
                     
-            await db.execute("""INSERT INTO tournament_players(player_id, tournament_id, registration_id, is_squad_captain, timestamp, is_checked_in, mii_name, can_host, is_invite, selected_fc_id, 
+            async with db.execute("""INSERT INTO tournament_players(player_id, tournament_id, registration_id, is_squad_captain, timestamp, is_checked_in, mii_name, can_host, is_invite, selected_fc_id, 
                              is_representative, is_bagger_clause, is_approved)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""", (self.player_id, self.tournament_id, registration_id, self.is_squad_captain, timestamp, is_checked_in, self.mii_name, self.can_host, 
-                self.is_invite, selected_fc_id, self.is_representative, self.is_bagger_clause, self.is_approved))
+                self.is_invite, selected_fc_id, self.is_representative, self.is_bagger_clause, self.is_approved)) as cursor:
+                tp_id = cursor.lastrowid
+                if tp_id is None:
+                    raise Problem('Bad Request', status=400)
+            
+            async with db.execute(f"""
+                                SELECT id, fc, type, player_id, is_verified, is_primary, creation_date, description, is_active
+                                FROM friend_codes f WHERE f.player_id = ? AND f.type = ? AND f.is_active = true
+                                """, (self.player_id, game_fc_map[game])) as cursor:
+                rows = await cursor.fetchall()
+                friend_codes = [FriendCode(*row) for row in rows]
+            
             await db.commit()
+            return SquadPlayerDetails(
+                tp_id, self.player_id, registration_id, timestamp,
+                is_checked_in, self.is_approved, True,
+                self.mii_name, self.can_host, player_name,
+                player_country_code, player_is_banned, discord, self.selected_fc_id, friend_codes,
+                self.is_squad_captain, self.is_representative, self.is_invite,  self.is_bagger_clause
+            )
 
 @dataclass
 class EditPlayerRegistrationCommand(Command[None]):

--- a/src/backend/common/data/commands/tournaments/registrations.py
+++ b/src/backend/common/data/commands/tournaments/registrations.py
@@ -151,7 +151,7 @@ class RegisterPlayerCommand(Command[SquadPlayerDetails]):
             )
 
 @dataclass
-class EditPlayerRegistrationCommand(Command[None]):
+class EditPlayerRegistrationCommand(Command[PlayerRegistrationUpdate]):
     tournament_id: int
     registration_id: int
     player_id: int
@@ -166,7 +166,7 @@ class EditPlayerRegistrationCommand(Command[None]):
     is_approved: bool | None
     is_privileged: bool
     
-    async def handle(self, db_wrapper: DBWrapper) -> None:
+    async def handle(self, db_wrapper: DBWrapper) -> PlayerRegistrationUpdate:
         async with db_wrapper.connect() as db:
             async with db.execute("SELECT is_squad, mii_name_required, registrations_open, require_single_fc, bagger_clause_enabled, checkins_open FROM tournaments WHERE id = ?", 
                                   (self.tournament_id,)) as cursor:
@@ -196,7 +196,7 @@ class EditPlayerRegistrationCommand(Command[None]):
                 row = await cursor.fetchone()
                 if not row:
                     raise Problem("Registration not found", status=404)
-                registration_id, curr_is_invite, curr_is_rep, curr_squad_captain, curr_is_checked_in, curr_bagger_clause, curr_approved = row
+                tp_id, curr_is_invite, curr_is_rep, curr_squad_captain, curr_is_checked_in, curr_bagger_clause, curr_approved = row
 
             # if we specify None on any of these fields, we don't want to change them
             is_representative = self.is_representative
@@ -264,8 +264,13 @@ class EditPlayerRegistrationCommand(Command[None]):
                                  (False, self.tournament_id, self.registration_id, self.player_id))
             await db.execute("""UPDATE tournament_players SET mii_name = ?, can_host = ?, is_invite = ?, is_checked_in = ?, is_squad_captain = ?, 
                              selected_fc_id = ?, is_representative = ?, is_bagger_clause = ?, is_approved = ? WHERE id = ?""", (
-                self.mii_name, self.can_host, self.is_invite, is_checked_in, is_squad_captain, self.selected_fc_id, is_representative, is_bagger_clause, is_approved, registration_id))
+                self.mii_name, self.can_host, self.is_invite, is_checked_in, is_squad_captain, self.selected_fc_id, is_representative, is_bagger_clause, is_approved, tp_id))
             await db.commit()
+            return PlayerRegistrationUpdate(
+                tp_id, is_checked_in, is_approved, self.mii_name, self.can_host,
+                self.selected_fc_id, is_squad_captain, bool(is_representative),
+                self.is_invite, is_bagger_clause
+            )
 
 @dataclass
 class UnregisterPlayerCommand(Command[None]):

--- a/src/backend/common/data/commands/tournaments/squads.py
+++ b/src/backend/common/data/commands/tournaments/squads.py
@@ -9,7 +9,7 @@ from common.data.models import *
 
 
 @dataclass
-class CreateSquadCommand(Command[None]):
+class CreateSquadCommand(Command[int]):
     squad_name: str | None
     squad_tag: str | None
     squad_color: int
@@ -23,7 +23,7 @@ class CreateSquadCommand(Command[None]):
     is_approved: bool
     is_privileged: bool = False
 
-    async def handle(self, db_wrapper: DBWrapper) -> None:
+    async def handle(self, db_wrapper: DBWrapper) -> int:
         timestamp = int(datetime.now(timezone.utc).timestamp())
         async with db_wrapper.connect() as db:
             # check if tournament registrations are open and that our arguments are correct for the current tournament
@@ -85,7 +85,9 @@ class CreateSquadCommand(Command[None]):
             async with db.execute("""INSERT INTO tournament_registrations(name, tag, color, timestamp, tournament_id, is_registered, is_approved)
                 VALUES (?, ?, ?, ?, ?, ?, ?)""", (self.squad_name, self.squad_tag, self.squad_color, timestamp, self.tournament_id, True, self.is_approved)) as cursor:
                 registration_id = cursor.lastrowid
-            await db.commit()
+
+                if registration_id is None:
+                    raise Problem("Bad request", status=400)
 
             is_checked_in = True if bool(checkins_open) else self.is_checked_in
             
@@ -94,9 +96,10 @@ class CreateSquadCommand(Command[None]):
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""", (self.captain_player_id, self.tournament_id, registration_id, True, timestamp, is_checked_in, self.mii_name, self.can_host, False,
                 selected_fc_id, False, self.is_bagger_clause, self.is_approved))
             await db.commit()
+            return registration_id
 
 @dataclass
-class RegisterTeamTournamentCommand(Command[int | None]):
+class RegisterTeamTournamentCommand(Command[int]):
     tournament_id: int
     squad_name: str
     squad_tag: str
@@ -107,7 +110,7 @@ class RegisterTeamTournamentCommand(Command[int | None]):
     is_approved: bool
     is_privileged: bool = False
 
-    async def handle(self, db_wrapper: DBWrapper) -> int | None:
+    async def handle(self, db_wrapper: DBWrapper) -> int:
         if len(self.roster_ids) == 0:
             raise Problem("Must register at least one roster", status=400)
         if not self.is_privileged and len(self.players) == 0:
@@ -214,7 +217,8 @@ class RegisterTeamTournamentCommand(Command[int | None]):
             async with db.execute("""INSERT INTO tournament_registrations(name, tag, color, timestamp, tournament_id, is_registered, is_approved)
                 VALUES (?, ?, ?, ?, ?, ?, ?)""", (self.squad_name, self.squad_tag, self.squad_color, timestamp, self.tournament_id, True, self.is_approved)) as cursor:
                 registration_id = cursor.lastrowid
-            await db.commit()
+                if registration_id is None:
+                    raise Problem('Bad request', status=400)
             
             # link our rosters to this tournament squad
             team_squad_rows = [(roster, registration_id, self.tournament_id) for roster in self.roster_ids]

--- a/src/backend/common/data/commands/tournaments/squads.py
+++ b/src/backend/common/data/commands/tournaments/squads.py
@@ -236,7 +236,7 @@ class RegisterTeamTournamentCommand(Command[int]):
             return registration_id
 
 @dataclass
-class EditSquadCommand(Command[None]):
+class EditSquadCommand(Command[TournamentSquadUpdate]):
     tournament_id: int
     registration_id: int
     squad_name: str | None
@@ -245,13 +245,13 @@ class EditSquadCommand(Command[None]):
     is_registered: bool | None
     is_approved: bool | None
 
-    async def handle(self, db_wrapper: DBWrapper) -> None:
+    async def handle(self, db_wrapper: DBWrapper) -> TournamentSquadUpdate:
         async with db_wrapper.connect() as db:
-            async with db.execute("SELECT is_approved, name, tag, color, is_registered FROM tournament_registrations WHERE id = ? AND tournament_id = ?", (self.registration_id, self.tournament_id)) as cursor:
+            async with db.execute("SELECT id, is_approved, name, tag, color, is_registered FROM tournament_registrations WHERE id = ? AND tournament_id = ?", (self.registration_id, self.tournament_id)) as cursor:
                 row = await cursor.fetchone()
                 if not row:
                     raise Problem("Squad not found", status=400)
-                curr_is_approved, curr_name, curr_tag, curr_color, curr_registered = row
+                squad_id, curr_is_approved, curr_name, curr_tag, curr_color, curr_registered = row
             is_approved = curr_is_approved if self.is_approved is None else self.is_approved
             name = curr_name if self.squad_name is None else self.squad_name
             tag = curr_tag if self.squad_tag is None else self.squad_tag
@@ -266,6 +266,7 @@ class EditSquadCommand(Command[None]):
             if not is_registered:
                 await db.execute("DELETE FROM tournament_players WHERE registration_id = ? AND tournament_id = ?", (self.registration_id, self.tournament_id))
             await db.commit()
+            return TournamentSquadUpdate(squad_id, name, tag, color, is_registered, is_approved)
 
 @dataclass
 class CheckSquadCaptainPermissionsCommand(Command[None]):

--- a/src/backend/common/data/models/squads.py
+++ b/src/backend/common/data/models/squads.py
@@ -89,6 +89,19 @@ class TournamentSquadDetails():
     rosters: list[RosterBasic]
 
 @dataclass
+class PlayerRegistrationUpdate:
+    id: int
+    is_checked_in: bool
+    is_approved: bool
+    mii_name: str | None
+    can_host: bool
+    selected_fc_id: int | None
+    is_squad_captain: bool
+    is_representative: bool
+    is_invite: bool
+    is_bagger_clause: bool
+    
+@dataclass
 class MyTournamentRegistration():
     squad: TournamentSquadDetails
     player: TournamentPlayerDetails | None

--- a/src/backend/common/data/models/squads.py
+++ b/src/backend/common/data/models/squads.py
@@ -89,6 +89,15 @@ class TournamentSquadDetails():
     rosters: list[RosterBasic]
 
 @dataclass
+class TournamentSquadUpdate:
+    id: int
+    name: str | None
+    tag: str | None
+    color: int
+    is_registered: bool
+    is_approved: bool
+
+@dataclass
 class PlayerRegistrationUpdate:
     id: int
     is_checked_in: bool

--- a/src/frontend/src/lib/components/tournaments/TournamentPlayerList.svelte
+++ b/src/frontend/src/lib/components/tournaments/TournamentPlayerList.svelte
@@ -102,11 +102,12 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
-    const result = await response.json();
+
     if (response.status < 300) {
       window.location.reload();
     } else {
-      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.MAKE_CAPTAIN_FAILED()}: ${result['title']}`);
+      const { title } = await response.json();
+      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.MAKE_CAPTAIN_FAILED()}: ${title}`);
     }
   }
 
@@ -122,11 +123,12 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
-    const result = await response.json();
+
     if (response.status < 300) {
       window.location.reload();
     } else {
-      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.MAKE_REPRESENTATIVE_FAILED()}: ${result['title']}`);
+      const { title } = await response.json();
+      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.MAKE_REPRESENTATIVE_FAILED()}: ${title}`);
     }
   }
 

--- a/src/frontend/src/lib/components/tournaments/TournamentPlayerList.svelte
+++ b/src/frontend/src/lib/components/tournaments/TournamentPlayerList.svelte
@@ -53,11 +53,12 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
-    const result = await response.json();
+
     if (response.status < 300) {
       window.location.reload();
     } else {
-      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.UNREGISTER_PLAYER_FAILED()}: ${result['title']}`);
+      const { title } = await response.json();
+      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.UNREGISTER_PLAYER_FAILED()}: ${title}`);
     }
   }
 
@@ -77,11 +78,11 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
-    const result = await response.json();
     if (response.status < 300) {
       window.location.reload();
     } else {
-      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.KICK_PLAYER_FAILED()}: ${result['title']}`);
+      const { title } = await response.json();
+      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.KICK_PLAYER_FAILED()}: ${title}`);
     }
   }
 
@@ -141,11 +142,12 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
-    const result = await response.json();
+
     if (response.status < 300) {
       window.location.reload();
     } else {
-      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.REMOVE_REPRESENTATIVE_FAILED()}: ${result['title']}`);
+      const { title } = await response.json();
+      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.REMOVE_REPRESENTATIVE_FAILED()}: ${title}`);
     }
   }
 
@@ -171,11 +173,12 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
-    const result = await response.json();
+
     if (response.status < 300) {
       window.location.reload();
     } else {
-      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.UNREGISTER_FAILED()}: ${result['title']}`);
+      const { title } = await response.json();
+      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.UNREGISTER_FAILED()}: ${title}`);
     }
   }
 </script>

--- a/src/frontend/src/lib/components/tournaments/TournamentSquadList.svelte
+++ b/src/frontend/src/lib/components/tournaments/TournamentSquadList.svelte
@@ -79,11 +79,12 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
-    const result = await response.json();
+
     if (response.status < 300) {
       window.location.reload();
     } else {
-      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.UNREGISTER_SQUAD_FAILED()}: ${result['title']}`);
+      const { title } = await response.json();
+      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.UNREGISTER_SQUAD_FAILED()}: ${title}`);
     }
   }
 

--- a/src/frontend/src/lib/components/tournaments/registration/ManageSquadRosters.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/ManageSquadRosters.svelte
@@ -78,11 +78,12 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
-    const result = await response.json();
+
     if (response.status < 300) {
       window.location.reload();
     } else {
-      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.REMOVE_ROSTER_FAILED()}: ${result['title']}`);
+      const { title } = await response.json();
+      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.REMOVE_ROSTER_FAILED()}: ${title}`);
     }
   }
 </script>

--- a/src/frontend/src/lib/components/tournaments/registration/MyRegistration.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/MyRegistration.svelte
@@ -33,11 +33,12 @@
       body: JSON.stringify(payload),
     });
     working = false;
-    const result = await response.json();
+
     if (response.status < 300) {
       window.location.reload();
     } else {
-      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.CHECK_IN_OUT_FAILED()}: ${result['title']}`);
+      const { title } = await response.json();
+      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.CHECK_IN_OUT_FAILED()}: ${title}`);
     }
   }
 </script>

--- a/src/frontend/src/lib/components/tournaments/registration/MySquad.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/MySquad.svelte
@@ -81,11 +81,12 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
-    const result = await response.json();
+
     if (response.status < 300) {
       window.location.reload();
     } else {
-      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.UNREGISTER_FAILED()}: ${result['title']}`);
+      const { title } = await response.json();
+      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.UNREGISTER_FAILED()}: ${title}`);
     }
   }
 

--- a/src/frontend/src/lib/components/tournaments/registration/TournamentInviteList.svelte
+++ b/src/frontend/src/lib/components/tournaments/registration/TournamentInviteList.svelte
@@ -94,11 +94,12 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
-    const result = await response.json();
+
     if (response.status < 300) {
       window.location.reload();
     } else {
-      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.DECLINE_INVITE_FAILED()}: ${result['title']}`);
+      const { title } = await response.json();
+      alert(`${$LL.TOURNAMENTS.REGISTRATIONS.DECLINE_INVITE_FAILED()}: ${title}`);
     }
   }
 </script>


### PR DESCRIPTION
## Changes
- The `registration_id` is now returned when a player/squad registers for a tournament and the response code has been updated to `201 Created` https://github.com/MarioKartCentral/MarioKartCentral/commit/736c7074db413fea88715f3d9b6defbcec3c53de
- Endpoints with responses not returning data have been updated to `204 No Content` https://github.com/MarioKartCentral/MarioKartCentral/commit/9723ef150b7c5717ba54c0d7fa9e83403f1aa255 https://github.com/MarioKartCentral/MarioKartCentral/commit/328d66824e88ff3affde8887a6e2f23ca4340921
- Player registration details are now returned when a player is registered for a tournament https://github.com/MarioKartCentral/MarioKartCentral/commit/28456f8e96c3777580925dbf1797894c55dc8317
- Updated player/squad registration details are now returned when there has been an update to a registration (e.g. accepts an invite, tag change) https://github.com/MarioKartCentral/MarioKartCentral/commit/28456f8e96c3777580925dbf1797894c55dc8317 https://github.com/MarioKartCentral/MarioKartCentral/commit/e870c6c982d2c420018b97e27b01916c2cc1e91e

## Note
There is currently no update to the response when rosters are added to a tournament squad to see if there is a requirement to support or to refactor some of the code.