### PR TITLE
feat(frontend): Add breadcrumb navigation

### DIFF
--- a/src/frontend/src/lib/components/common/Section.svelte
+++ b/src/frontend/src/lib/components/common/Section.svelte
@@ -32,7 +32,6 @@
     font-size: 20px;
   }
   .section-container {
-    max-width: 1200px;
     margin: 20px auto 20px auto;
     background-color: rgba(255, 255, 255, 0.15);
   }

--- a/src/frontend/src/lib/components/common/breadcrumb/Breadcrumb.svelte
+++ b/src/frontend/src/lib/components/common/breadcrumb/Breadcrumb.svelte
@@ -1,0 +1,15 @@
+<nav aria-label="Breadcrumb">
+  <ol class="flex flex-wrap items-center">
+    <slot />
+  </ol>
+</nav>
+
+<style>
+  nav {
+    width: max-content;
+    max-width: 100%;
+  }
+  ol {
+    font-size: 11pt;
+  }
+</style>

--- a/src/frontend/src/lib/components/common/breadcrumb/BreadcrumbItem.svelte
+++ b/src/frontend/src/lib/components/common/breadcrumb/BreadcrumbItem.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+  import LL from '$i18n/i18n-svelte';
+  import { ChevronLeftOutline, ChevronRightOutline, HomeSolid } from 'flowbite-svelte-icons';
+  import { twMerge } from 'tailwind-merge';
+
+  export let home: boolean = false;
+  export let href: string | undefined = undefined;
+  export let returnText: string | undefined = undefined;
+  export let truncate: boolean = true;
+  export let current: boolean = false;
+
+  const tag = href ? 'a' : 'span';
+
+  type ChevronProps = {
+    'aria-hidden': boolean;
+    tabindex: number;
+    size: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+  };
+
+  const chevronProps: ChevronProps = {
+    'aria-hidden': true,
+    tabindex: -1,
+    size: 'xl',
+  };
+
+  const truncateLiClasses = truncate ? 'max-w-[350px]' : '';
+  const truncateInnerClasses = truncate ? 'overflow-hidden text-ellipsis' : '';
+</script>
+
+<li class={truncateLiClasses}>
+  {#if !home}
+    <span class="mx-2 shrink-0 text-gray-100 hidden sm:inline">
+      <ChevronRightOutline {...chevronProps} />
+    </span>
+  {/if}
+  <svelte:element
+    this={tag}
+    aria-current={current ? 'page' : undefined}
+    class={twMerge('item-inner', truncateInnerClasses)}
+    {href}
+  >
+    {#if home}
+      <HomeSolid ariaLabel={$LL.NAVBAR.HOME_PAGE()} />
+    {:else}
+      <span class="me-2 shrink-0 bg-primary-700 rounded-[50%] sm:hidden">
+        <ChevronLeftOutline {...chevronProps} color="white" />
+      </span>
+    {/if}
+    {#if returnText}
+      <span class={twMerge('sm:hidden', truncateInnerClasses)}>{returnText}</span>
+      <span class="hidden sm:inline"><slot /></span>
+    {:else}
+      <span><slot /></span>
+    {/if}
+  </svelte:element>
+</li>
+
+<style>
+  li {
+    list-style-type: none;
+    flex-shrink: 0;
+    display: none;
+    white-space: nowrap;
+    align-items: center;
+  }
+
+  li:last-child {
+    color: white;
+  }
+
+  li:nth-last-child(2) {
+    display: flex;
+    font-weight: 600;
+  }
+
+  a[aria-current='page'],
+  span[aria-current='page'] {
+    font-weight: 600;
+  }
+
+  .item-inner {
+    display: flex;
+    align-items: center;
+  }
+
+  @media (min-width: 640px) {
+    li {
+      display: flex;
+    }
+
+    li:nth-last-child(2) {
+      font-weight: revert-layer;
+    }
+
+    li:not(:last-child) {
+      color: oklch(92.8% 0.006 264.531);
+    }
+
+    .item-inner {
+      display: revert-layer;
+      align-items: unset;
+    }
+  }
+</style>

--- a/src/frontend/src/lib/components/registry/players/PlayerProfileEdit.svelte
+++ b/src/frontend/src/lib/components/registry/players/PlayerProfileEdit.svelte
@@ -13,6 +13,8 @@
   import EditPlayerDetails from './EditPlayerDetails.svelte';
   import RegisterForm from '$lib/components/login/RegisterForm.svelte';
   import ChangeEmail from '$lib/components/login/ChangeEmail.svelte';
+  import Breadcrumb from '$lib/components/common/breadcrumb/Breadcrumb.svelte';
+  import BreadcrumbItem from '$lib/components/common/breadcrumb/BreadcrumbItem.svelte';
 
   export let player: PlayerInfo;
 
@@ -119,13 +121,15 @@
   }
 </script>
 
-<Section header={$LL.PLAYERS.PROFILE.PLAYER_PROFILE()}>
-  <div slot="header_content">
-    <Button href="/{$page.params.lang}/registry/players/profile?id={player.id}"
-      >{$LL.PLAYERS.PROFILE.BACK_TO_PROFILE()}</Button
-    >
-  </div>
-</Section>
+<Breadcrumb>
+  <BreadcrumbItem home href="/" />
+  <BreadcrumbItem href="/{$page.params.lang}/registry/players">{$LL.NAVBAR.PLAYERS()}</BreadcrumbItem>
+  <BreadcrumbItem
+    href="/{$page.params.lang}/registry/players/profile?id={player.id}"
+    returnText={$LL.PLAYERS.PROFILE.BACK_TO_PROFILE()}>{player.name}</BreadcrumbItem
+  >
+  <BreadcrumbItem current>{$LL.PLAYERS.PROFILE.EDIT_PROFILE()}</BreadcrumbItem>
+</Breadcrumb>
 
 {#if check_permission(user_info, permissions.edit_profile, true)}
   <Section header={$LL.PLAYERS.PROFILE.PLAYER_DETAILS()}>

--- a/src/frontend/src/lib/components/registry/teams/EditTeam.svelte
+++ b/src/frontend/src/lib/components/registry/teams/EditTeam.svelte
@@ -13,6 +13,8 @@
   import { user } from '$lib/stores/stores';
   import LogoUpload from '$lib/components/common/LogoUpload.svelte';
   import Input from '$lib/components/common/Input.svelte';
+  import Breadcrumb from '$lib/components/common/breadcrumb/Breadcrumb.svelte';
+  import BreadcrumbItem from '$lib/components/common/breadcrumb/BreadcrumbItem.svelte';
 
   export let is_mod = false;
 
@@ -112,11 +114,15 @@
 </svelte:head>
 
 {#if team}
-  <Section header={$LL.TEAMS.EDIT.TEAM_PAGE()}>
-    <div slot="header_content">
-      <Button href="/{$page.params.lang}/registry/teams/profile?id={team.id}">{$LL.TEAMS.EDIT.BACK_TO_TEAM()}</Button>
-    </div>
-  </Section>
+  <Breadcrumb>
+    <BreadcrumbItem home href="/" />
+    <BreadcrumbItem href="/{$page.params.lang}/registry/teams">{$LL.NAVBAR.TEAMS()}</BreadcrumbItem>
+    <BreadcrumbItem
+      href="/{$page.params.lang}/registry/teams/profile?id={team.id}"
+      returnText={$LL.TEAMS.EDIT.BACK_TO_TEAM()}>{team.name}</BreadcrumbItem
+    >
+    <BreadcrumbItem current>{$LL.TEAMS.PROFILE.EDIT_TEAM()}</BreadcrumbItem>
+  </Breadcrumb>
   {#if !is_mod}
     {#if check_team_permission(user_info, team_permissions.edit_team_name_tag, id)}
       <Section header={$LL.TEAMS.EDIT.TEAM_NAME_TAG()}>

--- a/src/frontend/src/lib/components/registry/teams/ManageRosters.svelte
+++ b/src/frontend/src/lib/components/registry/teams/ManageRosters.svelte
@@ -13,6 +13,8 @@
   import { sortFilterRosters } from '$lib/util/util';
   import Input from '$lib/components/common/Input.svelte';
   import ColorSelect from '$lib/components/common/ColorSelect.svelte';
+  import Breadcrumb from '$lib/components/common/breadcrumb/Breadcrumb.svelte';
+  import BreadcrumbItem from '$lib/components/common/breadcrumb/BreadcrumbItem.svelte';
 
   export let is_mod = false;
 
@@ -75,11 +77,15 @@
 </svelte:head>
 
 {#if team}
-  <Section header={$LL.TEAMS.EDIT.TEAM_PAGE()}>
-    <div slot="header_content">
-      <Button href="/{$page.params.lang}/registry/teams/profile?id={team.id}">{$LL.TEAMS.EDIT.BACK_TO_TEAM()}</Button>
-    </div>
-  </Section>
+  <Breadcrumb>
+    <BreadcrumbItem home href="/" />
+    <BreadcrumbItem href="/{$page.params.lang}/registry/teams">{$LL.NAVBAR.TEAMS()}</BreadcrumbItem>
+    <BreadcrumbItem
+      href="/{$page.params.lang}/registry/teams/profile?id={team.id}"
+      returnText={$LL.TEAMS.EDIT.BACK_TO_TEAM()}>{team.name}</BreadcrumbItem
+    >
+    <BreadcrumbItem current>{$LL.TEAMS.PROFILE.ROSTERS()}</BreadcrumbItem>
+  </Breadcrumb>
   {#if check_team_permission(user_info, team_permissions.manage_rosters, id)}
     {#each sortFilterRosters(team.rosters, is_mod) as roster (roster.id)}
       <TeamRosterManage {roster} {is_mod} />

--- a/src/frontend/src/lib/components/tournaments/series/SeriesInfo.svelte
+++ b/src/frontend/src/lib/components/tournaments/series/SeriesInfo.svelte
@@ -9,6 +9,8 @@
   import MarkdownBox from '$lib/components/common/MarkdownBox.svelte';
   import LL from '$i18n/i18n-svelte';
   import DiscordInviteButton from '$lib/components/common/buttons/DiscordInviteButton.svelte';
+  import Breadcrumb from '$lib/components/common/breadcrumb/Breadcrumb.svelte';
+  import BreadcrumbItem from '$lib/components/common/breadcrumb/BreadcrumbItem.svelte';
 
   export let series: TournamentSeries;
 
@@ -18,9 +20,16 @@
   });
 </script>
 
+<Breadcrumb>
+  <BreadcrumbItem home href="/" />
+  <BreadcrumbItem
+    href="/{$page.params.lang}/tournaments/series"
+    returnText={$LL.TOURNAMENTS.SERIES.BACK_TO_SERIES_LISTING()}>{$LL.NAVBAR.TOURNAMENT_SERIES()}</BreadcrumbItem
+  >
+  <BreadcrumbItem current>{series.series_name}</BreadcrumbItem>
+</Breadcrumb>
 <Section header={$LL.TOURNAMENTS.SERIES.SERIES_INFO()}>
   <div slot="header_content">
-    <Button href="/{$page.params.lang}/tournaments/series">{$LL.TOURNAMENTS.SERIES.BACK_TO_SERIES_LISTING()}</Button>
     {#if check_series_permission(user_info, series_permissions.edit_series, series.id)}
       <Button href="/{$page.params.lang}/tournaments/series/edit?id={series.id}">{$LL.TOURNAMENTS.SERIES.EDIT()}</Button
       >

--- a/src/frontend/src/routes/[lang]/moderator/users/edit/+page.svelte
+++ b/src/frontend/src/routes/[lang]/moderator/users/edit/+page.svelte
@@ -11,6 +11,8 @@
   import { check_permission, permissions } from '$lib/util/permissions';
   import LL from '$i18n/i18n-svelte';
   import ApiTokenDisplay from '$lib/components/user/APITokenDisplay.svelte';
+  import Breadcrumb from '$lib/components/common/breadcrumb/Breadcrumb.svelte';
+  import BreadcrumbItem from '$lib/components/common/breadcrumb/BreadcrumbItem.svelte';
 
   let id: number | null = null;
   let user_found = true;
@@ -84,13 +86,49 @@
 
 {#if check_permission(user_info, permissions.edit_user)}
   {#if edit_user}
-    <Section header={$LL.MODERATOR.MANAGE_USERS.BACK_TO_USER_LIST()}>
-      <div slot="header_content">
-        <Button href="/{$page.params.lang}/moderator/users">{$LL.COMMON.BACK()}</Button>
-      </div>
-    </Section>
+    <Breadcrumb>
+      <BreadcrumbItem home href="/" />
+      <BreadcrumbItem
+        href="/{$page.params.lang}/moderator/users"
+        returnText={$LL.MODERATOR.MANAGE_USERS.BACK_TO_USER_LIST()}
+      >
+        {$LL.NAVBAR.MOD_PANEL.MANAGE_USERS()}
+      </BreadcrumbItem>
+      <BreadcrumbItem current>{$LL.MODERATOR.MANAGE_USERS.EDIT_USER()}</BreadcrumbItem>
+    </Breadcrumb>
     <Section header={$LL.MODERATOR.MANAGE_USERS.EDIT_USER_HEADER({ user_id: edit_user.id })}>
       <form on:submit|preventDefault={editUser}>
+        <div class="option">
+          <div class="label">
+            {$LL.COMMON.PLAYER()}
+          </div>
+          <div>
+            {#if edit_user.player}
+              <a href="/{$page.params.lang}/registry/players/profile?id={edit_user.player.id}">
+                <div class="flex">
+                  <div>
+                    <Flag country_code={edit_user.player.country_code} />
+                  </div>
+                  <div>
+                    {edit_user.player.name}
+                  </div>
+                </div>
+              </a>
+            {:else}
+              {$LL.MODERATOR.MANAGE_USERS.USER_NO_PLAYER()}
+            {/if}
+          </div>
+        </div>
+        <div class="option">
+          <div class="label">{$LL.DISCORD.DISCORD()}</div>
+          <div>
+            {#if edit_user.player?.discord}
+              <DiscordDisplay discord={edit_user.player.discord} enableUserIdToggle />
+            {:else}
+              {$LL.MODERATOR.MANAGE_USERS.USER_NO_DISCORD()}
+            {/if}
+          </div>
+        </div>
         <div class="option">
           <div class="label">
             <label for="email">{$LL.LOGIN.EMAIL()}</label>
@@ -141,37 +179,6 @@
                   required
                 />
               </div>
-            {/if}
-          </div>
-        </div>
-        <div class="option">
-          <div class="label">
-            {$LL.COMMON.PLAYER()}
-          </div>
-          <div>
-            {#if edit_user.player}
-              <a href="/{$page.params.lang}/registry/players/profile?id={edit_user.player.id}">
-                <div class="flex">
-                  <div>
-                    <Flag country_code={edit_user.player.country_code} />
-                  </div>
-                  <div>
-                    {edit_user.player.name}
-                  </div>
-                </div>
-              </a>
-            {:else}
-              {$LL.MODERATOR.MANAGE_USERS.USER_NO_PLAYER()}
-            {/if}
-          </div>
-        </div>
-        <div class="option">
-          <div class="label">{$LL.DISCORD.DISCORD()}</div>
-          <div>
-            {#if edit_user.player?.discord}
-              <DiscordDisplay discord={edit_user.player.discord} enableUserIdToggle />
-            {:else}
-              {$LL.MODERATOR.MANAGE_USERS.USER_NO_DISCORD()}
             {/if}
           </div>
         </div>

--- a/src/frontend/src/routes/[lang]/posts/+page.svelte
+++ b/src/frontend/src/routes/[lang]/posts/+page.svelte
@@ -15,11 +15,6 @@
   });
 </script>
 
-<Section header={$LL.POSTS.BACK_TO_HOMEPAGE()}>
-  <div slot="header_content">
-    <Button href="/{$page.params.lang}/">{$LL.COMMON.BACK()}</Button>
-  </div>
-</Section>
 <Section header={$LL.POSTS.ANNOUNCEMENTS()}>
   <div slot="header_content">
     {#if check_permission(user_info, permissions.manage_posts)}

--- a/src/frontend/src/routes/[lang]/posts/create/+page.svelte
+++ b/src/frontend/src/routes/[lang]/posts/create/+page.svelte
@@ -14,15 +14,14 @@
   });
 </script>
 
-<Breadcrumb>
-  <BreadcrumbItem home href="/" />
-  <BreadcrumbItem href="/{$page.params.lang}/posts" returnText={$LL.POSTS.BACK_TO_ANNOUNCEMENTS()}
-    >{$LL.POSTS.ANNOUNCEMENTS()}</BreadcrumbItem
-  >
-  <BreadcrumbItem current>{$LL.POSTS.CREATE_POST()}</BreadcrumbItem>
-</Breadcrumb>
-
 {#if user_info.is_checked}
+  <Breadcrumb>
+    <BreadcrumbItem home href="/" />
+    <BreadcrumbItem href="/{$page.params.lang}/posts" returnText={$LL.POSTS.BACK_TO_ANNOUNCEMENTS()}
+      >{$LL.POSTS.ANNOUNCEMENTS()}</BreadcrumbItem
+    >
+    <BreadcrumbItem current>{$LL.POSTS.CREATE_POST()}</BreadcrumbItem>
+  </Breadcrumb>
   {#if check_permission(user_info, permissions.manage_posts)}
     <CreateEditPost />
   {:else}

--- a/src/frontend/src/routes/[lang]/posts/create/+page.svelte
+++ b/src/frontend/src/routes/[lang]/posts/create/+page.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import Section from '$lib/components/common/Section.svelte';
   import { page } from '$app/stores';
-  import Button from '$lib/components/common/buttons/Button.svelte';
   import CreateEditPost from '$lib/components/posts/CreateEditPost.svelte';
   import LL from '$i18n/i18n-svelte';
   import { user } from '$lib/stores/stores';
   import type { UserInfo } from '$lib/types/user-info';
   import { check_permission, permissions } from '$lib/util/permissions';
+  import Breadcrumb from '$lib/components/common/breadcrumb/Breadcrumb.svelte';
+  import BreadcrumbItem from '$lib/components/common/breadcrumb/BreadcrumbItem.svelte';
 
   let user_info: UserInfo;
   user.subscribe((value) => {
@@ -14,11 +14,13 @@
   });
 </script>
 
-<Section header={$LL.POSTS.BACK_TO_ANNOUNCEMENTS()}>
-  <div slot="header_content">
-    <Button href="/{$page.params.lang}/posts">{$LL.COMMON.BACK()}</Button>
-  </div>
-</Section>
+<Breadcrumb>
+  <BreadcrumbItem home href="/" />
+  <BreadcrumbItem href="/{$page.params.lang}/posts" returnText={$LL.POSTS.BACK_TO_ANNOUNCEMENTS()}
+    >{$LL.POSTS.ANNOUNCEMENTS()}</BreadcrumbItem
+  >
+  <BreadcrumbItem current>{$LL.POSTS.CREATE_POST()}</BreadcrumbItem>
+</Breadcrumb>
 
 {#if user_info.is_checked}
   {#if check_permission(user_info, permissions.manage_posts)}

--- a/src/frontend/src/routes/[lang]/posts/edit/+page.svelte
+++ b/src/frontend/src/routes/[lang]/posts/edit/+page.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-  import Section from '$lib/components/common/Section.svelte';
   import { page } from '$app/stores';
-  import Button from '$lib/components/common/buttons/Button.svelte';
   import CreateEditPost from '$lib/components/posts/CreateEditPost.svelte';
   import { onMount } from 'svelte';
   import LL from '$i18n/i18n-svelte';
   import { user } from '$lib/stores/stores';
   import type { UserInfo } from '$lib/types/user-info';
   import { check_permission, permissions } from '$lib/util/permissions';
+  import Breadcrumb from '$lib/components/common/breadcrumb/Breadcrumb.svelte';
+  import BreadcrumbItem from '$lib/components/common/breadcrumb/BreadcrumbItem.svelte';
 
   let post_id = 0;
 
@@ -22,13 +22,19 @@
   });
 </script>
 
-<Section header={$LL.POSTS.BACK_TO_POST()}>
-  <div slot="header_content">
-    <Button href="/{$page.params.lang}/posts/view?id={post_id}">{$LL.POSTS.BACK_TO_POST()}</Button>
-  </div>
-</Section>
-
 {#if user_info.is_checked && post_id}
+  <Breadcrumb>
+    <BreadcrumbItem home href="/" />
+    <BreadcrumbItem href="/{$page.params.lang}/posts" returnText={$LL.POSTS.BACK_TO_ANNOUNCEMENTS()}
+      >{$LL.POSTS.ANNOUNCEMENTS()}</BreadcrumbItem
+    >
+
+    <BreadcrumbItem href="/{$page.params.lang}/posts/view?id={post_id}" returnText={$LL.POSTS.BACK_TO_POST()}
+      >{post_id}</BreadcrumbItem
+    >
+
+    <BreadcrumbItem current>{$LL.POSTS.EDIT_POST()}</BreadcrumbItem>
+  </Breadcrumb>
   {#if check_permission(user_info, permissions.manage_posts)}
     <CreateEditPost postId={post_id} />
   {:else}

--- a/src/frontend/src/routes/[lang]/posts/view/+page.svelte
+++ b/src/frontend/src/routes/[lang]/posts/view/+page.svelte
@@ -2,9 +2,9 @@
   import PostDisplay from '$lib/components/posts/PostDisplay.svelte';
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
-  import Section from '$lib/components/common/Section.svelte';
-  import Button from '$lib/components/common/buttons/Button.svelte';
   import LL from '$i18n/i18n-svelte';
+  import Breadcrumb from '$lib/components/common/breadcrumb/Breadcrumb.svelte';
+  import BreadcrumbItem from '$lib/components/common/breadcrumb/BreadcrumbItem.svelte';
 
   let post_id = 0;
 
@@ -14,11 +14,13 @@
   });
 </script>
 
-<Section header={$LL.POSTS.BACK_TO_ANNOUNCEMENTS()}>
-  <div slot="header_content">
-    <Button href="/{$page.params.lang}/posts">{$LL.COMMON.BACK()}</Button>
-  </div>
-</Section>
 {#if post_id}
+  <Breadcrumb>
+    <BreadcrumbItem home href="/" />
+    <BreadcrumbItem href="/{$page.params.lang}/posts" returnText={$LL.POSTS.BACK_TO_ANNOUNCEMENTS()}
+      >{$LL.POSTS.ANNOUNCEMENTS()}</BreadcrumbItem
+    >
+    <BreadcrumbItem current>{post_id}</BreadcrumbItem>
+  </Breadcrumb>
   <PostDisplay id={post_id} />
 {/if}

--- a/src/frontend/src/routes/[lang]/tournaments/details/+page.svelte
+++ b/src/frontend/src/routes/[lang]/tournaments/details/+page.svelte
@@ -12,6 +12,8 @@
   import AccordionItem from '$lib/components/common/AccordionItem.svelte';
   import LL from '$i18n/i18n-svelte';
   import TournamentPosts from '$lib/components/tournaments/TournamentPosts.svelte';
+  import Breadcrumb from '$lib/components/common/breadcrumb/Breadcrumb.svelte';
+  import BreadcrumbItem from '$lib/components/common/breadcrumb/BreadcrumbItem.svelte';
 
   let id = 0;
 
@@ -37,6 +39,13 @@
 </svelte:head>
 
 {#if tournament}
+  <Breadcrumb>
+    <BreadcrumbItem home href="/" />
+    <BreadcrumbItem href="/{$page.params.lang}/tournaments" returnText={$LL.NAVBAR.TOURNAMENT_LISTING()}
+      >{$LL.NAVBAR.TOURNAMENTS()}</BreadcrumbItem
+    >
+    <BreadcrumbItem current>{tournament.name}</BreadcrumbItem>
+  </Breadcrumb>
   <TournamentInfo {tournament} />
   <Section header={$LL.TOURNAMENTS.DETAILS()}>
     <Accordion>

--- a/src/frontend/src/routes/[lang]/tournaments/edit_placements/+page.svelte
+++ b/src/frontend/src/routes/[lang]/tournaments/edit_placements/+page.svelte
@@ -8,6 +8,8 @@
   import LL from '$i18n/i18n-svelte';
   import { check_tournament_permission, tournament_permissions } from '$lib/util/permissions';
   import { user } from '$lib/stores/stores';
+  import Breadcrumb from '$lib/components/common/breadcrumb/Breadcrumb.svelte';
+  import BreadcrumbItem from '$lib/components/common/breadcrumb/BreadcrumbItem.svelte';
 
   let tournamentId: number;
   let placements: TournamentPlacementList;
@@ -42,14 +44,16 @@
 </script>
 
 {#if isLoaded}
+  <Breadcrumb>
+    <BreadcrumbItem home href="/" />
+    <BreadcrumbItem href="/{$page.params.lang}/tournaments">{$LL.NAVBAR.TOURNAMENTS()}</BreadcrumbItem>
+    <BreadcrumbItem
+      href="/{$page.params.lang}/tournaments/details?id={placements.tournament_id}"
+      returnText={$LL.TOURNAMENTS.BACK_TO_TOURNAMENT()}>{placements.tournament_id}</BreadcrumbItem
+    >
+    <BreadcrumbItem current>{$LL.TOURNAMENTS.PLACEMENTS.EDIT_PLACEMENTS()}</BreadcrumbItem>
+  </Breadcrumb>
   {#if placements && check_tournament_permission($user, tournament_permissions.manage_placements, placements.tournament_id)}
-    <Section header={$LL.TOURNAMENTS.BACK_TO_TOURNAMENT()}>
-      <div slot="header_content">
-        <Button href="/{$page.params.lang}/tournaments/details?id={placements.tournament_id}"
-          >{$LL.COMMON.BACK()}</Button
-        >
-      </div>
-    </Section>
     <Section header={$LL.TOURNAMENTS.PLACEMENTS.EDIT_PLACEMENTS()}>
       <div slot="header_content">
         <Button href="/{$page.params.lang}/tournaments/edit_placements/raw?id={placements.tournament_id}">

--- a/src/frontend/src/routes/[lang]/tournaments/edit_placements/raw/+page.svelte
+++ b/src/frontend/src/routes/[lang]/tournaments/edit_placements/raw/+page.svelte
@@ -5,6 +5,8 @@
   import type { TournamentPlacementList, TournamentPlacementSimple } from '$lib/types/tournament-placement';
   import Button from '$lib/components/common/buttons/Button.svelte';
   import LL from '$i18n/i18n-svelte';
+  import Breadcrumb from '$lib/components/common/breadcrumb/Breadcrumb.svelte';
+  import BreadcrumbItem from '$lib/components/common/breadcrumb/BreadcrumbItem.svelte';
 
   let id = 0;
   let is_loaded = false;
@@ -105,11 +107,15 @@
 </script>
 
 {#if is_loaded}
-  <Section header={$LL.TOURNAMENTS.BACK_TO_TOURNAMENT()}>
-    <div slot="header_content">
-      <Button href="/{$page.params.lang}/tournaments/details?id={id}">{$LL.COMMON.BACK()}</Button>
-    </div>
-  </Section>
+  <Breadcrumb>
+    <BreadcrumbItem home href="/" />
+    <BreadcrumbItem href="/{$page.params.lang}/tournaments">{$LL.NAVBAR.TOURNAMENTS()}</BreadcrumbItem>
+    <BreadcrumbItem
+      href="/{$page.params.lang}/tournaments/details?id={placements.tournament_id}"
+      returnText={$LL.TOURNAMENTS.BACK_TO_TOURNAMENT()}>{placements.tournament_id}</BreadcrumbItem
+    >
+    <BreadcrumbItem current>{$LL.TOURNAMENTS.PLACEMENTS.EDIT_PLACEMENTS()}</BreadcrumbItem>
+  </Breadcrumb>
   <Section header={$LL.TOURNAMENTS.PLACEMENTS.EDIT_PLACEMENTS()}>
     <div slot="header_content">
       <Button href="/{$page.params.lang}/tournaments/edit_placements?id={id}"

--- a/src/frontend/src/routes/[lang]/tournaments/edit_placements/raw_player_id/+page.svelte
+++ b/src/frontend/src/routes/[lang]/tournaments/edit_placements/raw_player_id/+page.svelte
@@ -5,6 +5,8 @@
   import type { TournamentPlacementSimplePlayerIDs } from '$lib/types/tournament-placement';
   import Button from '$lib/components/common/buttons/Button.svelte';
   import LL from '$i18n/i18n-svelte';
+  import Breadcrumb from '$lib/components/common/breadcrumb/Breadcrumb.svelte';
+  import BreadcrumbItem from '$lib/components/common/breadcrumb/BreadcrumbItem.svelte';
 
   let id = 0;
   let is_loaded = false;
@@ -82,11 +84,15 @@
 </script>
 
 {#if is_loaded}
-  <Section header={$LL.TOURNAMENTS.BACK_TO_TOURNAMENT()}>
-    <div slot="header_content">
-      <Button href="/{$page.params.lang}/tournaments/details?id={id}">{$LL.COMMON.BACK()}</Button>
-    </div>
-  </Section>
+  <Breadcrumb>
+    <BreadcrumbItem home href="/" />
+    <BreadcrumbItem href="/{$page.params.lang}/tournaments">{$LL.NAVBAR.TOURNAMENTS()}</BreadcrumbItem>
+    <BreadcrumbItem
+      href="/{$page.params.lang}/tournaments/details?id={id}"
+      returnText={$LL.TOURNAMENTS.BACK_TO_TOURNAMENT()}>{id}</BreadcrumbItem
+    >
+    <BreadcrumbItem current>{$LL.TOURNAMENTS.PLACEMENTS.EDIT_PLACEMENTS()}</BreadcrumbItem>
+  </Breadcrumb>
   <Section header="Placements Raw Input (Player IDs)">
     <div slot="header_content">
       <Button href="/{$page.params.lang}/tournaments/edit_placements?id={id}"

--- a/src/frontend/src/routes/[lang]/tournaments/manage_roles/+page.svelte
+++ b/src/frontend/src/routes/[lang]/tournaments/manage_roles/+page.svelte
@@ -4,13 +4,14 @@
   import type { Role } from '$lib/types/role';
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
-  import Button from '$lib/components/common/buttons/Button.svelte';
   import { get_highest_tournament_role_position } from '$lib/util/permissions';
   import { user } from '$lib/stores/stores';
   import type { UserInfo } from '$lib/types/user-info';
   import type { Tournament } from '$lib/types/tournament';
   import LL from '$i18n/i18n-svelte';
   import { check_tournament_permission, tournament_permissions } from '$lib/util/permissions';
+  import Breadcrumb from '$lib/components/common/breadcrumb/Breadcrumb.svelte';
+  import BreadcrumbItem from '$lib/components/common/breadcrumb/BreadcrumbItem.svelte';
 
   let roles: Role[] = [];
   let tournament_id = 0;
@@ -49,13 +50,17 @@
 </script>
 
 {#if user_info.is_checked}
+  <Breadcrumb>
+    <BreadcrumbItem home href="/" />
+    <BreadcrumbItem href="/{$page.params.lang}/tournaments">{$LL.NAVBAR.TOURNAMENTS()}</BreadcrumbItem>
+    <BreadcrumbItem
+      href="/{$page.params.lang}/tournaments/details?id={tournament_id}"
+      returnText={$LL.TOURNAMENTS.BACK_TO_TOURNAMENT()}>{tournament_id}</BreadcrumbItem
+    >
+    <BreadcrumbItem current>{$LL.TOURNAMENTS.TOURNAMENT_ROLES()}</BreadcrumbItem>
+  </Breadcrumb>
   {#if check_tournament_permission(user_info, tournament_permissions.manage_tournament_roles, tournament_id, series_id)}
     <Section header={$LL.TOURNAMENTS.TOURNAMENT_ROLES()}>
-      <div slot="header_content">
-        <Button href="/{$page.params.lang}/tournaments/details?id={tournament_id}"
-          >{$LL.TOURNAMENTS.BACK_TO_TOURNAMENT()}</Button
-        >
-      </div>
       {#if roles.length}
         <div class="select">
           <select bind:value={selected_role}>

--- a/src/frontend/src/routes/[lang]/tournaments/posts/create/+page.svelte
+++ b/src/frontend/src/routes/[lang]/tournaments/posts/create/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import Section from '$lib/components/common/Section.svelte';
   import { page } from '$app/stores';
-  import Button from '$lib/components/common/buttons/Button.svelte';
   import CreateEditPost from '$lib/components/posts/CreateEditPost.svelte';
   import { onMount } from 'svelte';
   import LL from '$i18n/i18n-svelte';
+  import Breadcrumb from '$lib/components/common/breadcrumb/Breadcrumb.svelte';
+  import BreadcrumbItem from '$lib/components/common/breadcrumb/BreadcrumbItem.svelte';
 
   let tournament_id = 0;
 
@@ -14,10 +14,16 @@
   });
 </script>
 
-<Section header={$LL.TOURNAMENTS.BACK_TO_TOURNAMENT()}>
-  <div slot="header_content">
-    <Button href="/{$page.params.lang}/tournaments/details?id={tournament_id}">{$LL.COMMON.BACK()}</Button>
-  </div>
-</Section>
+{#if tournament_id}
+  <Breadcrumb>
+    <BreadcrumbItem home href="/" />
+    <BreadcrumbItem href="/{$page.params.lang}/tournaments">{$LL.NAVBAR.TOURNAMENTS()}</BreadcrumbItem>
+    <BreadcrumbItem
+      href="/{$page.params.lang}/tournaments/details?id={tournament_id}"
+      returnText={$LL.TOURNAMENTS.BACK_TO_TOURNAMENT()}>{tournament_id}</BreadcrumbItem
+    >
+    <BreadcrumbItem current>{$LL.POSTS.CREATE_POST()}</BreadcrumbItem>
+  </Breadcrumb>
 
-<CreateEditPost tournamentId={tournament_id} />
+  <CreateEditPost tournamentId={tournament_id} />
+{/if}

--- a/src/frontend/src/routes/[lang]/tournaments/posts/edit/+page.svelte
+++ b/src/frontend/src/routes/[lang]/tournaments/posts/edit/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import Section from '$lib/components/common/Section.svelte';
   import { page } from '$app/stores';
-  import Button from '$lib/components/common/buttons/Button.svelte';
   import CreateEditPost from '$lib/components/posts/CreateEditPost.svelte';
   import { onMount } from 'svelte';
   import LL from '$i18n/i18n-svelte';
+  import Breadcrumb from '$lib/components/common/breadcrumb/Breadcrumb.svelte';
+  import BreadcrumbItem from '$lib/components/common/breadcrumb/BreadcrumbItem.svelte';
 
   let post_id = 0;
   let tournament_id = 0;
@@ -17,13 +17,19 @@
   });
 </script>
 
-<Section header={$LL.POSTS.BACK_TO_POST()}>
-  <div slot="header_content">
-    <Button href="/{$page.params.lang}/tournaments/posts/view?tournament_id={tournament_id}&id={post_id}"
-      >{$LL.COMMON.BACK()}</Button
+{#if tournament_id && post_id}
+  <Breadcrumb>
+    <BreadcrumbItem home href="/" />
+    <BreadcrumbItem href="/{$page.params.lang}/tournaments">{$LL.NAVBAR.TOURNAMENTS()}</BreadcrumbItem>
+    <BreadcrumbItem href="/{$page.params.lang}/tournaments/details?id={tournament_id}">{tournament_id}</BreadcrumbItem>
+    <BreadcrumbItem>{$LL.POSTS.TOURNAMENT_ANNOUNCEMENTS()}</BreadcrumbItem>
+    <BreadcrumbItem
+      href="/{$page.params.lang}/tournaments/posts/view?tournament_id={tournament_id}&id={post_id}"
+      returnText={$LL.POSTS.BACK_TO_POST()}>{post_id}</BreadcrumbItem
     >
-  </div>
-</Section>
+    <BreadcrumbItem current>{$LL.POSTS.EDIT_POST()}</BreadcrumbItem>
+  </Breadcrumb>
+{/if}
 
 {#key post_id}
   <CreateEditPost postId={post_id} tournamentId={tournament_id} />

--- a/src/frontend/src/routes/[lang]/tournaments/posts/view/+page.svelte
+++ b/src/frontend/src/routes/[lang]/tournaments/posts/view/+page.svelte
@@ -2,9 +2,9 @@
   import PostDisplay from '$lib/components/posts/PostDisplay.svelte';
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
-  import Section from '$lib/components/common/Section.svelte';
-  import Button from '$lib/components/common/buttons/Button.svelte';
   import LL from '$i18n/i18n-svelte';
+  import Breadcrumb from '$lib/components/common/breadcrumb/Breadcrumb.svelte';
+  import BreadcrumbItem from '$lib/components/common/breadcrumb/BreadcrumbItem.svelte';
 
   let post_id = 0;
   let tournament_id = 0;
@@ -18,12 +18,16 @@
 </script>
 
 {#key post_id}
-  <Section header={$LL.TOURNAMENTS.BACK_TO_TOURNAMENT()}>
-    <div slot="header_content">
-      <Button href="/{$page.params.lang}/tournaments/details?id={tournament_id}">{$LL.COMMON.BACK()}</Button>
-    </div>
-  </Section>
   {#if post_id}
+    <Breadcrumb>
+      <BreadcrumbItem home href="/" />
+      <BreadcrumbItem href="/{$page.params.lang}/tournaments">{$LL.NAVBAR.TOURNAMENTS()}</BreadcrumbItem>
+      <BreadcrumbItem
+        href="/{$page.params.lang}/tournaments/details?id={tournament_id}"
+        returnText={$LL.TOURNAMENTS.BACK_TO_TOURNAMENT()}>{tournament_id}</BreadcrumbItem
+      >
+      <BreadcrumbItem current>{$LL.POSTS.TOURNAMENT_ANNOUNCEMENTS()}</BreadcrumbItem>
+    </Breadcrumb>
     <PostDisplay id={post_id} {tournament_id} />
   {/if}
 {/key}

--- a/src/frontend/src/routes/[lang]/tournaments/series/posts/create/+page.svelte
+++ b/src/frontend/src/routes/[lang]/tournaments/series/posts/create/+page.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-  import Section from '$lib/components/common/Section.svelte';
   import { page } from '$app/stores';
-  import Button from '$lib/components/common/buttons/Button.svelte';
   import CreateEditPost from '$lib/components/posts/CreateEditPost.svelte';
   import { onMount } from 'svelte';
   import LL from '$i18n/i18n-svelte';
   import { user } from '$lib/stores/stores';
   import type { UserInfo } from '$lib/types/user-info';
   import { check_series_permission, series_permissions } from '$lib/util/permissions';
+  import Breadcrumb from '$lib/components/common/breadcrumb/Breadcrumb.svelte';
+  import BreadcrumbItem from '$lib/components/common/breadcrumb/BreadcrumbItem.svelte';
 
   let user_info: UserInfo;
   user.subscribe((value) => {
@@ -22,12 +22,17 @@
   });
 </script>
 
-<Section header={$LL.TOURNAMENTS.SERIES.BACK_TO_SERIES()}>
-  <div slot="header_content">
-    <Button href="/{$page.params.lang}/tournaments/series/details?id={series_id}">{$LL.COMMON.BACK()}</Button>
-  </div>
-</Section>
-
+{#if series_id}
+  <Breadcrumb>
+    <BreadcrumbItem home href="/" />
+    <BreadcrumbItem href="/{$page.params.lang}/tournaments/series">{$LL.NAVBAR.TOURNAMENT_SERIES()}</BreadcrumbItem>
+    <BreadcrumbItem
+      href="/{$page.params.lang}/tournaments/series/details?id={series_id}"
+      returnText={$LL.TOURNAMENTS.SERIES.BACK_TO_SERIES()}>{series_id}</BreadcrumbItem
+    >
+    <BreadcrumbItem current>{$LL.POSTS.CREATE_POST()}</BreadcrumbItem>
+  </Breadcrumb>
+{/if}
 {#if user_info.is_checked && series_id}
   {#if check_series_permission(user_info, series_permissions.manage_series_posts, series_id)}
     <CreateEditPost seriesId={series_id} />

--- a/src/frontend/src/routes/[lang]/tournaments/series/posts/edit/+page.svelte
+++ b/src/frontend/src/routes/[lang]/tournaments/series/posts/edit/+page.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-  import Section from '$lib/components/common/Section.svelte';
   import { page } from '$app/stores';
-  import Button from '$lib/components/common/buttons/Button.svelte';
   import CreateEditPost from '$lib/components/posts/CreateEditPost.svelte';
   import { onMount } from 'svelte';
   import LL from '$i18n/i18n-svelte';
   import { user } from '$lib/stores/stores';
   import type { UserInfo } from '$lib/types/user-info';
   import { check_series_permission, series_permissions } from '$lib/util/permissions';
+  import Breadcrumb from '$lib/components/common/breadcrumb/Breadcrumb.svelte';
+  import BreadcrumbItem from '$lib/components/common/breadcrumb/BreadcrumbItem.svelte';
 
   let user_info: UserInfo;
   user.subscribe((value) => {
@@ -25,14 +25,19 @@
   });
 </script>
 
-<Section header={$LL.POSTS.BACK_TO_POST()}>
-  <div slot="header_content">
-    <Button href="/{$page.params.lang}/tournaments/series/posts/view?series_id={series_id}&id={post_id}"
-      >{$LL.COMMON.BACK()}</Button
+{#if post_id}
+  <Breadcrumb>
+    <BreadcrumbItem home href="/" />
+    <BreadcrumbItem href="/{$page.params.lang}/tournaments/series">{$LL.NAVBAR.TOURNAMENT_SERIES()}</BreadcrumbItem>
+    <BreadcrumbItem href="/{$page.params.lang}/tournaments/series/details?id={series_id}">{series_id}</BreadcrumbItem>
+    <BreadcrumbItem>{$LL.POSTS.SERIES_ANNOUNCEMENTS()}</BreadcrumbItem>
+    <BreadcrumbItem
+      href="/{$page.params.lang}/tournaments/series/posts/view?series_id={series_id}&id={post_id}"
+      returnText={$LL.POSTS.BACK_TO_POST()}>{post_id}</BreadcrumbItem
     >
-  </div>
-</Section>
-
+    <BreadcrumbItem current>{$LL.POSTS.EDIT_POST()}</BreadcrumbItem>
+  </Breadcrumb>
+{/if}
 {#if user_info.is_checked && series_id}
   {#if check_series_permission(user_info, series_permissions.manage_series_posts, series_id)}
     {#key post_id}

--- a/src/frontend/src/routes/[lang]/tournaments/series/posts/view/+page.svelte
+++ b/src/frontend/src/routes/[lang]/tournaments/series/posts/view/+page.svelte
@@ -2,9 +2,9 @@
   import PostDisplay from '$lib/components/posts/PostDisplay.svelte';
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
-  import Section from '$lib/components/common/Section.svelte';
-  import Button from '$lib/components/common/buttons/Button.svelte';
   import LL from '$i18n/i18n-svelte';
+  import Breadcrumb from '$lib/components/common/breadcrumb/Breadcrumb.svelte';
+  import BreadcrumbItem from '$lib/components/common/breadcrumb/BreadcrumbItem.svelte';
 
   let post_id = 0;
   let series_id = 0;
@@ -18,12 +18,16 @@
 </script>
 
 {#key post_id}
-  <Section header={$LL.TOURNAMENTS.SERIES.BACK_TO_SERIES()}>
-    <div slot="header_content">
-      <Button href="/{$page.params.lang}/tournaments/series/details?id={series_id}">{$LL.COMMON.BACK()}</Button>
-    </div>
-  </Section>
   {#if post_id}
+    <Breadcrumb>
+      <BreadcrumbItem home href="/" />
+      <BreadcrumbItem href="/{$page.params.lang}/tournaments/series">{$LL.NAVBAR.TOURNAMENT_SERIES()}</BreadcrumbItem>
+      <BreadcrumbItem
+        href="/{$page.params.lang}/tournaments/series/details?id={series_id}"
+        returnText={$LL.TOURNAMENTS.SERIES.BACK_TO_SERIES()}>{series_id}</BreadcrumbItem
+      >
+      <BreadcrumbItem current>{$LL.POSTS.SERIES_ANNOUNCEMENTS()}</BreadcrumbItem>
+    </Breadcrumb>
     <PostDisplay id={post_id} {series_id} />
   {/if}
 {/key}


### PR DESCRIPTION
Adds a breadcrumb trial for higher-level navigation. Breadcrumbs are typically included on pages at least 3 levels deep. One feature not natively possible with Flowbite was the ability to filter items on mobile/smaller devices causing clutter to the UI.

Read more here: https://developer.mozilla.org/en-US/docs/Glossary/Breadcrumb

A `<BreadcrumbItem />` component takes in the following parameters:
- `home` - Displays the home icon
- `href` - Renders the current page title inside a ` <span/>` tag if not supplied, else an `<a/>` tag. Typically is omitted in the final item.
- `returnText` - placed on the penultimate instance inside the breadcrumb. This is so navigation is clear on all screen sizes (see the example below)
- `truncate` (default `true`) - prevents the breadcrumb from overflowing and item consuming too much space if dynamic values such as team/player names are passed through.
- `current`(default `false`)  - Adds `aria-current="page"` and applies distinct styling to differentiate itself from previous pages.

Items excluding the penultimate item are hidden on mobile screens using CSS.

Example usage:
```svelte
<Breadcrumb>
  <BreadcrumbItem home href="/" />
  <BreadcrumbItem href="/{$page.params.lang}/registry/players">{$LL.NAVBAR.PLAYERS()}</BreadcrumbItem>
  <BreadcrumbItem
    href="/{$page.params.lang}/registry/players/profile?id={player.id}"
    returnText={$LL.PLAYERS.PROFILE.BACK_TO_PROFILE()}>{player.name}</BreadcrumbItem
  >
  <BreadcrumbItem current>{$LL.PLAYERS.PROFILE.EDIT_PROFILE()}</BreadcrumbItem>
</Breadcrumb>
```

Desktop view (expanded)
<img width="1261" height="413" alt="image" src="https://github.com/user-attachments/assets/0746bb2a-f0a6-4932-af46-e73417f26956" />

Mobile view
<img width="548" height="393" alt="image" src="https://github.com/user-attachments/assets/f91476c4-a5a3-4bd2-a289-338efe1cf2a6" />

## Other Changes
- Removed the `max-width` property on the `<Section />` component to address alignment issues.
- Added breadcrumbs to tournament/series details pages.
- Moved the Player/Discord fields on the edit user page to the top for easier navigation to the profile. This is because applying the suggestion in https://github.com/MarioKartCentral/MarioKartCentral/issues/253 would break the breadcrumb's structure as the player profile page is not part of the linear path.