### PR TITLE
feat: add mkworld game formats support

### DIFF
--- a/src/backend/common/data/models/common.py
+++ b/src/backend/common/data/models/common.py
@@ -49,17 +49,18 @@ GameMode = Literal[
     "coin_runners",
     "renegade_roundup",
     "mixed",
+    "knockout_tour",
 ]
 FriendCodeType = Literal["switch", "nnid", "3ds", "mkw", "mkt"]
 game_fc_map: dict[Game, FriendCodeType] = {
-                    "mkworld": "switch",
-                    "mk8dx": "switch",
-                    "mk7": "3ds",
-                    "mk8": "nnid",
-                    "mkt": "mkt",
-                    "mkw": "mkw",
-                    "smk": "switch"
-                }
+    "mkworld": "switch",
+    "mk8dx": "switch",
+    "mk7": "3ds",
+    "mk8": "nnid",
+    "mkt": "mkt",
+    "mkw": "mkw",
+    "smk": "switch"
+}
 Approval = Literal["approved", "pending", "denied"]
 CountryCode = Literal["AF", "AX", "AL", "DZ", "AS", "AD", "AO", "AI", "AQ", "AG", "AR", "AM", "AW", "AU", "AT", "AZ", "BS",
                       "BH", "BD", "BB", "BY", "BE", "BZ", "BJ", "BM", "BT", "BO", "BQ", "BA", "BW", "BV", "BR", "IO", "BN",

--- a/src/frontend/src/i18n/de/index.ts
+++ b/src/frontend/src/i18n/de/index.ts
@@ -422,6 +422,7 @@ const de: Translation = {
     SELECT: 'Wählen Sie einen Modus...',
     '150CC': '150cc',
     '200CC': '200cc',
+    KNOCKOUT_TOUR: 'K.-o.-Tour',
     MIXED_BATTLE: 'Schlacht (gemischt)',
     BALLOON_BATTLE: 'Ballonschlacht',
     SHINE_THIEF: 'Insignien-Diebstahl',

--- a/src/frontend/src/i18n/en-us/index.ts
+++ b/src/frontend/src/i18n/en-us/index.ts
@@ -417,6 +417,7 @@ const en_us: BaseTranslation = {
     SELECT: 'Select a mode...',
     '150CC': '150cc',
     '200CC': '200cc',
+    KNOCKOUT_TOUR: 'Knockout Tour',
     MIXED_BATTLE: 'Battle (Mixed)',
     BALLOON_BATTLE: 'Balloon Battle',
     SHINE_THIEF: 'Shine Thief',

--- a/src/frontend/src/i18n/es/index.ts
+++ b/src/frontend/src/i18n/es/index.ts
@@ -421,6 +421,7 @@ const es: Translation = {
     SELECT: 'Selecciona un modo...',
     '150CC': '150cc',
     '200CC': '200cc',
+    KNOCKOUT_TOUR: 'Supervivencia',
     MIXED_BATTLE: 'Batalla (Mixta)',
     BALLOON_BATTLE: 'Batalla de globos',
     SHINE_THIEF: 'Asalto al sol',

--- a/src/frontend/src/i18n/fr/index.ts
+++ b/src/frontend/src/i18n/fr/index.ts
@@ -422,6 +422,7 @@ const fr: Translation = {
     SELECT: 'Selectionner un mode...',
     '150CC': '150cc',
     '200CC': '200cc',
+    KNOCKOUT_TOUR: 'Survie',
     MIXED_BATTLE: 'Batailles (Mixte)',
     BALLOON_BATTLE: 'Bataille de ballons',
     SHINE_THIEF: 'Capture de soleil',

--- a/src/frontend/src/i18n/i18n-types.ts
+++ b/src/frontend/src/i18n/i18n-types.ts
@@ -1530,6 +1530,10 @@ type RootTranslation = {
 		 */
 		'200CC': string
 		/**
+		 * K​n​o​c​k​o​u​t​ ​T​o​u​r
+		 */
+		KNOCKOUT_TOUR: string
+		/**
 		 * B​a​t​t​l​e​ ​(​M​i​x​e​d​)
 		 */
 		MIXED_BATTLE: string
@@ -7148,6 +7152,10 @@ export type TranslationFunctions = {
 		 * 200cc
 		 */
 		'200CC': () => LocalizedString
+		/**
+		 * Knockout Tour
+		 */
+		KNOCKOUT_TOUR: () => LocalizedString
 		/**
 		 * Battle (Mixed)
 		 */

--- a/src/frontend/src/i18n/ja/index.ts
+++ b/src/frontend/src/i18n/ja/index.ts
@@ -419,6 +419,7 @@ const ja: Translation = {
     SELECT: 'Select a mode...',
     '150CC': '150cc',
     '200CC': '200cc',
+    KNOCKOUT_TOUR: 'サバイバル',
     MIXED_BATTLE: 'バトル (ミックス)',
     BALLOON_BATTLE: 'ふうせんバトル',
     SHINE_THIEF: 'いただきシャイン',

--- a/src/frontend/src/lib/components/badges/badge_styles.css
+++ b/src/frontend/src/lib/components/badges/badge_styles.css
@@ -130,7 +130,8 @@ span.badge {
 }
 
 .mode_200cc_badge,
-.mode_ct_badge {
+.mode_ct_badge,
+.mode_knockout_tour_badge {
   background-color: #d4008b;
   border: 1px solid #990063;
 }

--- a/src/frontend/src/lib/util/util.ts
+++ b/src/frontend/src/lib/util/util.ts
@@ -75,17 +75,18 @@ export const game_order: { [key: string]: number } = {
 export const mode_order: { [key: string]: number } = {
   '150cc': 0,
   '200cc': 1,
-  mixed_battle: 2,
-  balloon_battle: 3,
-  shine_thief: 4,
-  bobomb_blast: 5,
-  coin_runners: 6,
-  renegade_roundup: 7,
-  match_race: 8,
-  mixed: 9,
-  rt: 10,
-  ct: 11,
-  vsrace: 12,
+  knockout_tour: 2,
+  mixed_battle: 3,
+  balloon_battle: 4,
+  shine_thief: 5,
+  bobomb_blast: 6,
+  coin_runners: 7,
+  renegade_roundup: 8,
+  match_race: 9,
+  mixed: 10,
+  rt: 11,
+  ct: 12,
+  vsrace: 13,
 };
 export const fc_types = ['switch', 'nnid', 'mkw', 'mkt', '3ds'];
 export const game_fc_types: { [key: string]: string } = {
@@ -105,7 +106,7 @@ export const fc_type_order: { [key: string]: number } = {
   '3ds': 4,
 };
 export const valid_modes: { [key: string]: string[] } = {
-  mkworld: ['150cc'],
+  mkworld: ['150cc', 'knockout_tour', 'mixed_battle', 'balloon_battle', 'coin_runners', 'bobomb_blast', 'mixed'],
   mk8dx: [
     '150cc',
     '200cc',


### PR DESCRIPTION
- Adds knockout tour as a format
  - Translation strings taken from [here](https://www.mariowiki.com/Mario_Kart_World#Knockout_Tour)
- Add coin runners, balloon battle and bobomb blast to Mario Kart World
- Add mixed format, mixed battle to Mario Kart World